### PR TITLE
Add world state component with tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,13 +1,19 @@
 """Entry point for the text adventure prototype."""
 
-def main() -> None:
-    """Start the placeholder game loop.
+from textadventure import WorldState
 
-    For now we simply greet the user to confirm the module executes
-    successfully. Additional gameplay logic will be added in
-    subsequent tasks.
-    """
+
+def main() -> None:
+    """Start the placeholder game loop."""
+
+    world = WorldState()
+
     print("Welcome to the Text Adventure prototype!")
+    print(f"You are currently at: {world.location}.")
+    if world.inventory:
+        print(f"Inventory: {', '.join(sorted(world.inventory))}")
+    else:
+        print("Inventory: (empty)")
 
 
 if __name__ == "__main__":

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -1,0 +1,5 @@
+"""Core package for the text adventure framework."""
+
+from .world_state import WorldState
+
+__all__ = ["WorldState"]

--- a/src/textadventure/world_state.py
+++ b/src/textadventure/world_state.py
@@ -1,0 +1,119 @@
+"""Utilities for tracking the world state of the adventure."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Set
+
+
+@dataclass
+class WorldState:
+    """Represents the player's current context within the world.
+
+    The world state keeps track of three key pieces of information:
+
+    * ``location`` – the player's current position in the world.
+    * ``inventory`` – a collection of unique items currently held by the player.
+    * ``history`` – a chronological log of noteworthy events that occurred.
+
+    The helper methods on this class ensure that interactions with the world
+    remain validated and that the history reflects only meaningful changes.
+    """
+
+    location: str = "starting-area"
+    inventory: Set[str] = field(default_factory=set)
+    history: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        self.location = self._validate_label(self.location, "location")
+
+    def move_to(self, location: str, *, record_event: bool = True) -> None:
+        """Update the current location of the player.
+
+        Args:
+            location: The name of the new location.
+            record_event: When ``True`` the transition is captured in the
+                history log.
+
+        Raises:
+            ValueError: If ``location`` is an empty string.
+        """
+
+        validated = self._validate_label(location, "location")
+        if validated == self.location:
+            return
+
+        self.location = validated
+        if record_event:
+            self.record_event(f"Moved to {validated}")
+
+    def add_item(self, item: str, *, record_event: bool = True) -> bool:
+        """Add an item to the player's inventory.
+
+        Args:
+            item: The item identifier to add.
+            record_event: When ``True`` the acquisition is logged.
+
+        Returns:
+            ``True`` if the item was added to the inventory, ``False`` if it was
+            already present.
+
+        Raises:
+            ValueError: If ``item`` is empty.
+        """
+
+        validated = self._validate_label(item, "item")
+        if validated in self.inventory:
+            return False
+
+        self.inventory.add(validated)
+        if record_event:
+            self.record_event(f"Picked up {validated}")
+        return True
+
+    def remove_item(self, item: str, *, record_event: bool = True) -> bool:
+        """Remove an item from the player's inventory if it exists.
+
+        Args:
+            item: The item identifier to remove.
+            record_event: When ``True`` the removal is noted in the history.
+
+        Returns:
+            ``True`` if the item was removed, ``False`` if it was not present.
+
+        Raises:
+            ValueError: If ``item`` is empty.
+        """
+
+        validated = self._validate_label(item, "item")
+        if validated not in self.inventory:
+            return False
+
+        self.inventory.remove(validated)
+        if record_event:
+            self.record_event(f"Dropped {validated}")
+        return True
+
+    def record_event(self, description: str) -> None:
+        """Add an event description to the history log."""
+
+        validated = self._validate_label(description, "event description")
+        self.history.append(validated)
+
+    def extend_history(self, descriptions: Iterable[str]) -> None:
+        """Bulk-add multiple event descriptions to the history."""
+
+        for description in descriptions:
+            self.record_event(description)
+
+    @staticmethod
+    def _validate_label(value: str, field_name: str) -> str:
+        """Strip and validate string values used for world descriptors."""
+
+        if not isinstance(value, str):
+            raise TypeError(f"{field_name} must be a string, got {type(value)!r}")
+
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError(f"{field_name} must be a non-empty string")
+        return stripped

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Test configuration for the text adventure project."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_world_state.py
+++ b/tests/test_world_state.py
@@ -1,0 +1,60 @@
+"""Unit tests for the :mod:`textadventure.world_state` module."""
+
+import pytest
+
+from textadventure import WorldState
+
+
+@pytest.fixture()
+def world_state() -> WorldState:
+    return WorldState(location="Atrium")
+
+
+def test_move_to_updates_location_and_records_event(world_state: WorldState) -> None:
+    world_state.move_to("Observatory")
+
+    assert world_state.location == "Observatory"
+    assert world_state.history[-1] == "Moved to Observatory"
+
+
+def test_move_to_ignores_redundant_moves(world_state: WorldState) -> None:
+    world_state.move_to("Atrium")
+
+    assert world_state.location == "Atrium"
+    assert world_state.history == []
+
+
+def test_add_and_remove_items_track_inventory_and_history(
+    world_state: WorldState,
+) -> None:
+    added = world_state.add_item("Ancient Key")
+    removed = world_state.remove_item("Ancient Key")
+
+    assert added is True
+    assert removed is True
+    assert "Ancient Key" not in world_state.inventory
+    assert world_state.history == [
+        "Picked up Ancient Key",
+        "Dropped Ancient Key",
+    ]
+
+
+def test_add_item_returns_false_when_duplicate(world_state: WorldState) -> None:
+    world_state.add_item("Lantern")
+
+    result = world_state.add_item("Lantern")
+
+    assert result is False
+    assert world_state.history == ["Picked up Lantern"]
+
+
+def test_record_event_validates_description(world_state: WorldState) -> None:
+    with pytest.raises(ValueError):
+        world_state.record_event("   ")
+
+
+def test_remove_item_returns_false_when_absent(world_state: WorldState) -> None:
+    result = world_state.remove_item("Map")
+
+    assert result is False
+    assert world_state.history == []


### PR DESCRIPTION
## Summary
- introduce a WorldState dataclass to manage location, inventory, and history details
- expose the WorldState from the package and surface it in the CLI entry point
- configure pytest to locate the src package and add unit tests for the world state

## Testing
- pytest -q
- black src tests

------
https://chatgpt.com/codex/tasks/task_e_68d89c8086d4832494ca106a7f43f384