### PR TITLE
Design story engine abstraction

### DIFF
--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -1,5 +1,6 @@
 """Core package for the text adventure framework."""
 
+from .story_engine import StoryChoice, StoryEngine, StoryEvent
 from .world_state import WorldState
 
-__all__ = ["WorldState"]
+__all__ = ["WorldState", "StoryChoice", "StoryEvent", "StoryEngine"]

--- a/src/textadventure/story_engine.py
+++ b/src/textadventure/story_engine.py
@@ -1,0 +1,111 @@
+"""Interfaces for proposing narrative events within the adventure."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Mapping, Sequence, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
+    from .world_state import WorldState
+
+
+def _validate_text(value: str, *, field_name: str) -> str:
+    """Validate and normalise free-form text fields used by story elements."""
+
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string, got {type(value)!r}")
+
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+    return stripped
+
+
+@dataclass(frozen=True)
+class StoryChoice:
+    """Represents a single actionable option offered to the player."""
+
+    command: str
+    description: str
+
+    def __post_init__(self) -> None:
+        command = _validate_text(self.command, field_name="command").lower()
+        description = _validate_text(self.description, field_name="choice description")
+
+        object.__setattr__(self, "command", command)
+        object.__setattr__(self, "description", description)
+
+
+@dataclass(frozen=True)
+class StoryEvent:
+    """Encapsulates the narrative response produced by a story engine."""
+
+    narration: str
+    choices: Sequence[StoryChoice] = field(default_factory=tuple)
+    metadata: Mapping[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        narration = _validate_text(self.narration, field_name="narration")
+        object.__setattr__(self, "narration", narration)
+
+        normalised_choices = tuple(self.choices)
+        seen_commands: set[str] = set()
+        for choice in normalised_choices:
+            if choice.command in seen_commands:
+                raise ValueError(f"duplicate choice command: {choice.command}")
+            seen_commands.add(choice.command)
+
+        object.__setattr__(self, "choices", normalised_choices)
+
+        if self.metadata is None:
+            metadata = MappingProxyType({})
+        else:
+            metadata = MappingProxyType(
+                {
+                    _validate_text(str(k), field_name="metadata key"):
+                        _validate_text(str(v), field_name="metadata value")
+                    for k, v in self.metadata.items()
+                }
+            )
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def has_choices(self) -> bool:
+        """Return ``True`` when the event offers at least one choice."""
+
+        return bool(self.choices)
+
+    def iter_choice_commands(self) -> Tuple[str, ...]:
+        """Return the available commands as a tuple for quick lookups."""
+
+        return tuple(choice.command for choice in self.choices)
+
+
+class StoryEngine(ABC):
+    """Abstract interface for components that drive narrative progression."""
+
+    @abstractmethod
+    def propose_event(
+        self,
+        world_state: WorldState,
+        *,
+        player_input: str | None = None,
+    ) -> StoryEvent:
+        """Produce the next story event based on the current context."""
+
+    def format_event(self, event: StoryEvent) -> str:
+        """Create a printable representation of a story event."""
+
+        lines = [event.narration]
+        if event.choices:
+            lines.append("")
+            for choice in event.choices:
+                lines.append(f"[{choice.command}] {choice.description}")
+        return "\n".join(lines)
+
+
+__all__ = ["StoryChoice", "StoryEvent", "StoryEngine"]
+

--- a/tests/test_story_engine.py
+++ b/tests/test_story_engine.py
@@ -1,0 +1,63 @@
+"""Tests for the story engine abstractions."""
+
+from __future__ import annotations
+
+import pytest
+
+from textadventure import StoryChoice, StoryEngine, StoryEvent, WorldState
+
+
+class DummyStoryEngine(StoryEngine):
+    """Simple concrete implementation used for exercising the interface."""
+
+    def propose_event(
+        self,
+        world_state: WorldState,
+        *,
+        player_input: str | None = None,
+    ) -> StoryEvent:
+        narration = f"You are at {world_state.location}."
+        choices = [StoryChoice("Look", "Survey the area")]
+        return StoryEvent(narration=narration, choices=choices)
+
+
+def test_story_choice_normalises_fields() -> None:
+    choice = StoryChoice("  Examine  ", "  Inspect the room  ")
+
+    assert choice.command == "examine"
+    assert choice.description == "Inspect the room"
+
+
+def test_story_event_rejects_duplicate_choice_commands() -> None:
+    with pytest.raises(ValueError):
+        StoryEvent(
+            narration="A fork in the road.",
+            choices=[
+                StoryChoice("Left", "Head into the forest"),
+                StoryChoice("left", "Take the same path again"),
+            ],
+        )
+
+
+def test_metadata_is_immutable_mapping() -> None:
+    event = StoryEvent(
+        narration="A mysterious wind howls.",
+        metadata={" mood ": " ominous "},
+    )
+
+    assert dict(event.metadata) == {"mood": "ominous"}
+    with pytest.raises(TypeError):
+        event.metadata["mood"] = "calm"  # type: ignore[index]
+
+
+def test_story_engine_format_event() -> None:
+    engine = DummyStoryEngine()
+    world = WorldState(location="clifftop")
+    event = engine.propose_event(world)
+
+    formatted = engine.format_event(event)
+
+    assert "You are at clifftop." in formatted
+    assert "[examine]" not in formatted
+    assert "[look]" in formatted
+    assert "Survey the area" in formatted


### PR DESCRIPTION
## Summary
- add a story engine module that defines StoryEngine, StoryEvent, and StoryChoice abstractions
- expose the new abstractions from the textadventure package for external use
- cover the story engine behaviours with dedicated unit tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d89de344a48324a7863f94824fe185