### PR TITLE
Add LLM client abstraction

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -11,7 +11,7 @@ This document captures recommended starting tasks for building out the text-adve
 ## Priority 1: Core Framework Skeleton
 - [x] Implement a `WorldState` object responsible for tracking locations, inventory, and history.
 - [x] Design an interface for a `StoryEngine` component that can propose narrative events based on the world state.
-- [ ] Provide an abstraction around LLM calls (e.g., `LLMClient`) that can be mocked during tests.
+- [x] Provide an abstraction around LLM calls (e.g., `LLMClient`) that can be mocked during tests.
 - [ ] Draft a simple command loop (CLI) that takes player input and routes it through the story engine.
 - [ ] Create an initial concrete `StoryEngine` implementation that returns scripted events for testing the loop.
 

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -1,6 +1,17 @@
 """Core package for the text adventure framework."""
 
+from .llm import LLMClient, LLMClientError, LLMMessage, LLMResponse, iter_contents
 from .story_engine import StoryChoice, StoryEngine, StoryEvent
 from .world_state import WorldState
 
-__all__ = ["WorldState", "StoryChoice", "StoryEvent", "StoryEngine"]
+__all__ = [
+    "WorldState",
+    "StoryChoice",
+    "StoryEvent",
+    "StoryEngine",
+    "LLMClient",
+    "LLMClientError",
+    "LLMMessage",
+    "LLMResponse",
+    "iter_contents",
+]

--- a/src/textadventure/llm.py
+++ b/src/textadventure/llm.py
@@ -1,0 +1,121 @@
+"""Abstractions for interacting with large language model providers."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Iterable, Mapping, MutableMapping, Sequence
+
+
+def _validate_text(value: str, *, field_name: str) -> str:
+    """Ensure text fields contain non-empty string values."""
+
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string, got {type(value)!r}")
+
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+    return stripped
+
+
+@dataclass(frozen=True)
+class LLMMessage:
+    """Represents a single message exchanged with an LLM service."""
+
+    role: str
+    content: str
+
+    def __post_init__(self) -> None:  # pragma: no cover - trivial setters
+        role = _validate_text(self.role, field_name="role").lower()
+        content = _validate_text(self.content, field_name="content")
+
+        object.__setattr__(self, "role", role)
+        object.__setattr__(self, "content", content)
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """Container describing the result returned by an LLM invocation."""
+
+    message: LLMMessage
+    usage: Mapping[str, int] = field(default_factory=dict)
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        usage_proxy = _frozen_int_mapping(self.usage, field_name="usage")
+        metadata_proxy = _frozen_str_mapping(self.metadata, field_name="metadata")
+
+        object.__setattr__(self, "usage", usage_proxy)
+        object.__setattr__(self, "metadata", metadata_proxy)
+
+
+def _frozen_int_mapping(mapping: Mapping[str, int] | MutableMapping[str, int], *, field_name: str) -> Mapping[str, int]:
+    """Validate that mapping values are integers and return an immutable view."""
+
+    if mapping is None:
+        data: Mapping[str, int] = {}
+    else:
+        data = {
+            _validate_text(str(key), field_name=f"{field_name} key"): _validate_int(value, field_name=f"{field_name} value")
+            for key, value in mapping.items()
+        }
+
+    return MappingProxyType(dict(data))
+
+
+def _validate_int(value: int, *, field_name: str) -> int:
+    if not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an int, got {type(value)!r}")
+    return value
+
+
+def _frozen_str_mapping(mapping: Mapping[str, str] | MutableMapping[str, str], *, field_name: str) -> Mapping[str, str]:
+    """Validate that mapping values are strings and return an immutable view."""
+
+    if mapping is None:
+        data: Mapping[str, str] = {}
+    else:
+        data = {
+            _validate_text(str(key), field_name=f"{field_name} key"):
+            _validate_text(str(value), field_name=f"{field_name} value")
+            for key, value in mapping.items()
+        }
+
+    return MappingProxyType(dict(data))
+
+
+class LLMClient(ABC):
+    """Abstract interface encapsulating calls to an LLM provider."""
+
+    @abstractmethod
+    def complete(self, messages: Sequence[LLMMessage], *, temperature: float | None = None) -> LLMResponse:
+        """Generate a completion from a set of chat-style messages."""
+
+    def complete_prompt(self, prompt: str, *, temperature: float | None = None) -> LLMResponse:
+        """Helper for providers that accept a single user prompt."""
+
+        message = LLMMessage(role="user", content=prompt)
+        return self.complete([message], temperature=temperature)
+
+
+class LLMClientError(RuntimeError):
+    """Base exception raised when the LLM client encounters a failure."""
+
+
+def iter_contents(messages: Iterable[LLMMessage]) -> Sequence[str]:
+    """Extract just the textual payloads from a collection of messages."""
+
+    return [message.content for message in messages]
+
+
+__all__ = [
+    "LLMClient",
+    "LLMClientError",
+    "LLMMessage",
+    "LLMResponse",
+    "iter_contents",
+]
+

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,78 @@
+"""Tests for the LLM abstraction layer."""
+
+import pytest
+
+from typing import Sequence
+
+from textadventure.llm import (
+    LLMClient,
+    LLMMessage,
+    LLMResponse,
+    iter_contents,
+)
+
+
+class DummyLLMClient(LLMClient):
+    """A simple client implementation for exercising the base helpers."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[LLMMessage]] = []
+
+    def complete(
+        self, messages: Sequence[LLMMessage], *, temperature: float | None = None
+    ) -> LLMResponse:
+        self.calls.append(list(messages))
+        return LLMResponse(message=messages[-1])
+
+
+def test_message_validation_and_normalisation() -> None:
+    message = LLMMessage(role="User", content="  Hello there  ")
+    assert message.role == "user"
+    assert message.content == "Hello there"
+
+
+@pytest.mark.parametrize("field, value", [("role", ""), ("content", "   ")])
+def test_message_validation_rejects_empty_strings(field: str, value: str) -> None:
+    kwargs = {"role": "user", "content": "hello"}
+    kwargs[field] = value
+
+    with pytest.raises(ValueError):
+        LLMMessage(**kwargs)  # type: ignore[arg-type]
+
+
+def test_response_immutability() -> None:
+    response = LLMResponse(
+        message=LLMMessage(role="assistant", content="Result"),
+        usage={"tokens": 42},
+        metadata={"model": "gpt"},
+    )
+
+    assert response.usage["tokens"] == 42
+    assert response.metadata["model"] == "gpt"
+
+    with pytest.raises(TypeError):
+        response.usage["tokens"] = 0  # type: ignore[index]
+
+    with pytest.raises(TypeError):
+        response.metadata["model"] = "other"  # type: ignore[index]
+
+
+def test_complete_prompt_helper_constructs_user_message() -> None:
+    client = DummyLLMClient()
+    client.complete_prompt("Inspect room", temperature=0.1)
+
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert len(call) == 1
+    assert call[0].role == "user"
+    assert call[0].content == "Inspect room"
+
+
+def test_iter_contents_returns_message_text() -> None:
+    messages = [
+        LLMMessage(role="system", content="Rules"),
+        LLMMessage(role="user", content="Go north"),
+    ]
+
+    assert iter_contents(messages) == ["Rules", "Go north"]
+


### PR DESCRIPTION
## Summary
- add an llm module defining chat message, response containers, and a reusable client interface
- expose the llm abstractions via the package exports
- cover the new module with unit tests and mark the backlog item as complete

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d89faeab6c832498404b87fea35e39