### PR TITLE
Add scripted story engine and interactive CLI loop

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -12,8 +12,8 @@ This document captures recommended starting tasks for building out the text-adve
 - [x] Implement a `WorldState` object responsible for tracking locations, inventory, and history.
 - [x] Design an interface for a `StoryEngine` component that can propose narrative events based on the world state.
 - [x] Provide an abstraction around LLM calls (e.g., `LLMClient`) that can be mocked during tests.
-- [ ] Draft a simple command loop (CLI) that takes player input and routes it through the story engine.
-- [ ] Create an initial concrete `StoryEngine` implementation that returns scripted events for testing the loop.
+- [x] Draft a simple command loop (CLI) that takes player input and routes it through the story engine.
+- [x] Create an initial concrete `StoryEngine` implementation that returns scripted events for testing the loop.
 
 ## Priority 2: Persistence & Memory
 - [ ] Define how game sessions will be persisted (in-memory first, followed by optional file-based persistence).
@@ -23,7 +23,7 @@ This document captures recommended starting tasks for building out the text-adve
 - [x] Write unit tests covering the world state mutations and narrative branching logic.
 - [ ] Set up fixtures or mocks for LLM interactions to keep tests deterministic.
 - [ ] Consider integrating type checking (e.g., `mypy`) and continuous integration workflows (GitHub Actions).
-- [ ] Add smoke tests for the CLI once the interactive loop is implemented.
+- [ ] Add smoke tests for the CLI once the interactive loop is implemented. (The scripted engine now supports manual runs.)
 
 ## Priority 4: Stretch Goals
 - [ ] Explore integrating external tools (e.g., knowledge bases or calculators) the agent can invoke during gameplay.

--- a/src/main.py
+++ b/src/main.py
@@ -1,19 +1,52 @@
 """Entry point for the text adventure prototype."""
 
-from textadventure import WorldState
+from __future__ import annotations
+
+from textadventure import StoryEngine, WorldState
+from textadventure.scripted_story_engine import ScriptedStoryEngine
+
+
+def run_cli(engine: StoryEngine, world: WorldState) -> None:
+    """Drive a very small interactive loop using ``input``/``print``."""
+
+    print("Welcome to the Text Adventure prototype!")
+    print("Type 'quit' at any time to end the session.\n")
+
+    event = engine.propose_event(world)
+    while True:
+        print(engine.format_event(event))
+        if not event.has_choices:
+            print("\nThe story has reached a natural stopping point.")
+            break
+
+        try:
+            raw_input = input("\n> ")
+        except EOFError:
+            print("\n\nReached end of input. Until next time!")
+            break
+        except KeyboardInterrupt:
+            print("\n\nInterrupted. Your progress is saved in spirit!")
+            break
+
+        player_input = raw_input.strip()
+        if not player_input:
+            event = engine.propose_event(world)
+            continue
+
+        lowered = player_input.lower()
+        if lowered in {"quit", "exit"}:
+            print("\nThanks for playing!")
+            break
+
+        event = engine.propose_event(world, player_input=player_input)
 
 
 def main() -> None:
-    """Start the placeholder game loop."""
+    """Start the scripted demo adventure."""
 
     world = WorldState()
-
-    print("Welcome to the Text Adventure prototype!")
-    print(f"You are currently at: {world.location}.")
-    if world.inventory:
-        print(f"Inventory: {', '.join(sorted(world.inventory))}")
-    else:
-        print("Inventory: (empty)")
+    engine = ScriptedStoryEngine()
+    run_cli(engine, world)
 
 
 if __name__ == "__main__":

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -2,6 +2,7 @@
 
 from .llm import LLMClient, LLMClientError, LLMMessage, LLMResponse, iter_contents
 from .story_engine import StoryChoice, StoryEngine, StoryEvent
+from .scripted_story_engine import ScriptedStoryEngine
 from .world_state import WorldState
 
 __all__ = [
@@ -9,6 +10,7 @@ __all__ = [
     "StoryChoice",
     "StoryEvent",
     "StoryEngine",
+    "ScriptedStoryEngine",
     "LLMClient",
     "LLMClientError",
     "LLMMessage",

--- a/src/textadventure/llm.py
+++ b/src/textadventure/llm.py
@@ -52,14 +52,18 @@ class LLMResponse:
         object.__setattr__(self, "metadata", metadata_proxy)
 
 
-def _frozen_int_mapping(mapping: Mapping[str, int] | MutableMapping[str, int], *, field_name: str) -> Mapping[str, int]:
+def _frozen_int_mapping(
+    mapping: Mapping[str, int] | MutableMapping[str, int], *, field_name: str
+) -> Mapping[str, int]:
     """Validate that mapping values are integers and return an immutable view."""
 
     if mapping is None:
         data: Mapping[str, int] = {}
     else:
         data = {
-            _validate_text(str(key), field_name=f"{field_name} key"): _validate_int(value, field_name=f"{field_name} value")
+            _validate_text(str(key), field_name=f"{field_name} key"): _validate_int(
+                value, field_name=f"{field_name} value"
+            )
             for key, value in mapping.items()
         }
 
@@ -72,15 +76,18 @@ def _validate_int(value: int, *, field_name: str) -> int:
     return value
 
 
-def _frozen_str_mapping(mapping: Mapping[str, str] | MutableMapping[str, str], *, field_name: str) -> Mapping[str, str]:
+def _frozen_str_mapping(
+    mapping: Mapping[str, str] | MutableMapping[str, str], *, field_name: str
+) -> Mapping[str, str]:
     """Validate that mapping values are strings and return an immutable view."""
 
     if mapping is None:
         data: Mapping[str, str] = {}
     else:
         data = {
-            _validate_text(str(key), field_name=f"{field_name} key"):
-            _validate_text(str(value), field_name=f"{field_name} value")
+            _validate_text(str(key), field_name=f"{field_name} key"): _validate_text(
+                str(value), field_name=f"{field_name} value"
+            )
             for key, value in mapping.items()
         }
 
@@ -91,10 +98,14 @@ class LLMClient(ABC):
     """Abstract interface encapsulating calls to an LLM provider."""
 
     @abstractmethod
-    def complete(self, messages: Sequence[LLMMessage], *, temperature: float | None = None) -> LLMResponse:
+    def complete(
+        self, messages: Sequence[LLMMessage], *, temperature: float | None = None
+    ) -> LLMResponse:
         """Generate a completion from a set of chat-style messages."""
 
-    def complete_prompt(self, prompt: str, *, temperature: float | None = None) -> LLMResponse:
+    def complete_prompt(
+        self, prompt: str, *, temperature: float | None = None
+    ) -> LLMResponse:
         """Helper for providers that accept a single user prompt."""
 
         message = LLMMessage(role="user", content=prompt)
@@ -118,4 +129,3 @@ __all__ = [
     "LLMResponse",
     "iter_contents",
 ]
-

--- a/src/textadventure/scripted_story_engine.py
+++ b/src/textadventure/scripted_story_engine.py
@@ -1,0 +1,174 @@
+"""A tiny, scripted story engine used for manual exploration and tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping
+
+from .story_engine import StoryChoice, StoryEngine, StoryEvent
+from .world_state import WorldState
+
+
+@dataclass(frozen=True)
+class _Transition:
+    """Description of how a command updates the world and narrative."""
+
+    narration: str
+    target: str | None = None
+    item: str | None = None
+
+
+@dataclass(frozen=True)
+class _Scene:
+    """Container describing a location and its available actions."""
+
+    description: str
+    choices: tuple[StoryChoice, ...]
+    transitions: Mapping[str, _Transition]
+
+    def command_list(self) -> str:
+        return ", ".join(choice.command for choice in self.choices)
+
+
+def _history_summary(world_state: WorldState) -> str:
+    if not world_state.history:
+        return "Your journal is blank—for now."
+
+    entries = "\n".join(f"- {entry}" for entry in world_state.history[-5:])
+    return f"You flip through your journal and read:\n{entries}"
+
+
+def _inventory_summary(world_state: WorldState) -> str:
+    if not world_state.inventory:
+        return "You pat your pockets but find nothing of note."
+
+    items = ", ".join(sorted(world_state.inventory))
+    return f"Your pack currently holds: {items}."
+
+
+class ScriptedStoryEngine(StoryEngine):
+    """A deterministic `StoryEngine` with two handcrafted locations."""
+
+    def __init__(self, *, scenes: Mapping[str, _Scene] | None = None):
+        if scenes is None:
+            scenes = _DEFAULT_SCENES
+        self._scenes: Mapping[str, _Scene] = scenes
+
+    def propose_event(
+        self,
+        world_state: WorldState,
+        *,
+        player_input: str | None = None,
+    ) -> StoryEvent:
+        scene = self._scenes.get(world_state.location)
+        if scene is None:
+            return StoryEvent(
+                narration=(
+                    "You find yourself in unfamiliar territory. "
+                    "There are no scripted events for this location yet."
+                ),
+                choices=(),
+            )
+
+        if player_input is None:
+            return StoryEvent(narration=scene.description, choices=scene.choices)
+
+        command = player_input.strip().lower()
+        if not command:
+            return StoryEvent(narration="Silence lingers...", choices=scene.choices)
+
+        if command == "journal":
+            return StoryEvent(
+                narration=_history_summary(world_state),
+                choices=scene.choices,
+            )
+
+        if command == "inventory":
+            return StoryEvent(
+                narration=_inventory_summary(world_state),
+                choices=scene.choices,
+            )
+
+        transition = scene.transitions.get(command)
+        if transition is None:
+            available = scene.command_list()
+            narration = (
+                f"You're not sure how to '{command}'. " f"Try one of: {available}."
+            )
+            return StoryEvent(narration=narration, choices=scene.choices)
+
+        narration = transition.narration
+
+        if transition.item:
+            newly_added = world_state.add_item(transition.item)
+            if newly_added:
+                narration += f"\n\nYou tuck the {transition.item} safely away."
+            else:
+                narration += f"\n\nYou already have the {transition.item}."
+
+        if transition.target:
+            world_state.move_to(transition.target)
+            follow_up_scene = self._scenes.get(world_state.location)
+            if follow_up_scene:
+                narration = f"{narration}\n\n{follow_up_scene.description}"
+                choices = follow_up_scene.choices
+            else:
+                choices = ()
+        else:
+            choices = scene.choices
+
+        return StoryEvent(narration=narration, choices=choices)
+
+
+_DEFAULT_SCENES: MutableMapping[str, _Scene] = {
+    "starting-area": _Scene(
+        description=(
+            "Sunlight filters through tall trees at the forest trailhead. "
+            "An old stone gate lies to the north, its archway draped in moss."
+        ),
+        choices=(
+            StoryChoice("look", "Take in the surroundings."),
+            StoryChoice("explore", "Head toward the mossy gate."),
+            StoryChoice("inventory", "Check what you're carrying."),
+            StoryChoice("journal", "Review the notes in your journal."),
+        ),
+        transitions={
+            "look": _Transition(
+                narration="You pause and listen to the rustling leaves."
+            ),
+            "explore": _Transition(
+                narration="You follow the worn path toward the gate.",
+                target="old-gate",
+            ),
+        },
+    ),
+    "old-gate": _Scene(
+        description=(
+            "The gate stands ajar, revealing a courtyard blanketed in mist. "
+            "A rusty key glints between the stones nearby."
+        ),
+        choices=(
+            StoryChoice("look", "Study the ancient masonry."),
+            StoryChoice("inspect", "Investigate the glinting object."),
+            StoryChoice("return", "Head back down the forest trail."),
+            StoryChoice("inventory", "Check your belongings."),
+            StoryChoice("journal", "Look over your recorded memories."),
+        ),
+        transitions={
+            "look": _Transition(
+                narration="Time has scarred the gate, but it still stands firm."
+            ),
+            "inspect": _Transition(
+                narration="You kneel and pick up the rusty key.",
+                item="rusty key",
+            ),
+            "return": _Transition(
+                narration="You retrace your steps to the trailhead.",
+                target="starting-area",
+            ),
+        },
+    ),
+}
+
+
+__all__ = ["ScriptedStoryEngine"]

--- a/src/textadventure/story_engine.py
+++ b/src/textadventure/story_engine.py
@@ -65,8 +65,9 @@ class StoryEvent:
         else:
             metadata = MappingProxyType(
                 {
-                    _validate_text(str(k), field_name="metadata key"):
-                        _validate_text(str(v), field_name="metadata value")
+                    _validate_text(str(k), field_name="metadata key"): _validate_text(
+                        str(v), field_name="metadata value"
+                    )
                     for k, v in self.metadata.items()
                 }
             )
@@ -108,4 +109,3 @@ class StoryEngine(ABC):
 
 
 __all__ = ["StoryChoice", "StoryEvent", "StoryEngine"]
-

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -75,4 +75,3 @@ def test_iter_contents_returns_message_text() -> None:
     ]
 
     assert iter_contents(messages) == ["Rules", "Go north"]
-

--- a/tests/test_scripted_story_engine.py
+++ b/tests/test_scripted_story_engine.py
@@ -1,0 +1,49 @@
+"""Tests for the `ScriptedStoryEngine` concrete implementation."""
+
+from __future__ import annotations
+
+from textadventure import WorldState
+from textadventure.scripted_story_engine import ScriptedStoryEngine
+
+
+def test_initial_event_describes_location() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world)
+
+    assert "trailhead" in event.narration
+    assert "look" in event.iter_choice_commands()
+
+
+def test_explore_transitions_to_gate() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world, player_input="explore")
+
+    assert world.location == "old-gate"
+    assert "gate" in event.narration.lower()
+    assert "courtyard" in event.narration.lower()
+
+
+def test_inspect_collects_key_once() -> None:
+    world = WorldState(location="old-gate")
+    engine = ScriptedStoryEngine()
+
+    first_event = engine.propose_event(world, player_input="inspect")
+    second_event = engine.propose_event(world, player_input="inspect")
+
+    assert "rusty key" in world.inventory
+    assert "tuck the rusty key" in first_event.narration
+    assert "already have" in second_event.narration
+
+
+def test_unknown_command_reprompts() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world, player_input="dance")
+
+    assert "not sure" in event.narration.lower()
+    assert "dance" in event.narration


### PR DESCRIPTION
## Summary
- add a scripted story engine with handcrafted scenes and inventory/journal support
- update the CLI entrypoint to run an interactive loop using the scripted engine
- cover the new engine with unit tests and note the CLI availability in TASKS.md

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8a0ce34d083249e37fd1e929b9e34