### PR TITLE
Add stub LLM fixture for deterministic tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -21,7 +21,8 @@ This document captures recommended starting tasks for building out the text-adve
 
 ## Priority 3: Testing & Tooling Enhancements
 - [x] Write unit tests covering the world state mutations and narrative branching logic.
-- [ ] Set up fixtures or mocks for LLM interactions to keep tests deterministic.
+- [x] Set up fixtures or mocks for LLM interactions to keep tests deterministic.
+  - Added a reusable `StubLLMClient` fixture that records invocations and replays canned responses.
 - [ ] Consider integrating type checking (e.g., `mypy`) and continuous integration workflows (GitHub Actions).
 - [ ] Add smoke tests for the CLI once the interactive loop is implemented. (The scripted engine now supports manual runs.)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test helpers and fixtures package for pytest discovery."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,55 @@
-"""Test configuration for the text adventure project."""
+"""Test configuration and utilities for the text adventure project."""
+
+from __future__ import annotations
 
 import sys
+from collections import deque
 from pathlib import Path
+from typing import Deque, Iterable, List, Sequence
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+from textadventure.llm import LLMClient, LLMMessage, LLMResponse
+
+
+class StubLLMClient(LLMClient):
+    """A deterministic LLM client used to keep tests reproducible."""
+
+    def __init__(self, *, replies: Iterable[str] | None = None) -> None:
+        self.calls: List[List[LLMMessage]] = []
+        self._replies: Deque[LLMResponse] = deque()
+        if replies:
+            for reply in replies:
+                self.enqueue_reply(reply)
+
+    def enqueue_reply(self, reply: str) -> None:
+        """Queue a canned assistant response for the next call."""
+
+        message = LLMMessage(role="assistant", content=reply)
+        self._replies.append(LLMResponse(message=message))
+
+    def complete(
+        self, messages: Sequence[LLMMessage], *, temperature: float | None = None
+    ) -> LLMResponse:
+        self.calls.append(list(messages))
+        if self._replies:
+            return self._replies.popleft()
+
+        fallback_content = messages[-1].content if messages else ""
+        fallback_message = LLMMessage(role="assistant", content=fallback_content)
+        return LLMResponse(message=fallback_message)
+
+
+@pytest.fixture
+def stub_llm_client() -> StubLLMClient:
+    """Return a stubbed LLM client that records calls and yields canned replies."""
+
+    return StubLLMClient()
+
+
+__all__ = ["StubLLMClient", "stub_llm_client"]

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -2,27 +2,9 @@
 
 import pytest
 
-from typing import Sequence
+from textadventure.llm import LLMMessage, LLMResponse, iter_contents
 
-from textadventure.llm import (
-    LLMClient,
-    LLMMessage,
-    LLMResponse,
-    iter_contents,
-)
-
-
-class DummyLLMClient(LLMClient):
-    """A simple client implementation for exercising the base helpers."""
-
-    def __init__(self) -> None:
-        self.calls: list[list[LLMMessage]] = []
-
-    def complete(
-        self, messages: Sequence[LLMMessage], *, temperature: float | None = None
-    ) -> LLMResponse:
-        self.calls.append(list(messages))
-        return LLMResponse(message=messages[-1])
+from .conftest import StubLLMClient
 
 
 def test_message_validation_and_normalisation() -> None:
@@ -58,7 +40,7 @@ def test_response_immutability() -> None:
 
 
 def test_complete_prompt_helper_constructs_user_message() -> None:
-    client = DummyLLMClient()
+    client = StubLLMClient()
     client.complete_prompt("Inspect room", temperature=0.1)
 
     assert len(client.calls) == 1
@@ -75,3 +57,15 @@ def test_iter_contents_returns_message_text() -> None:
     ]
 
     assert iter_contents(messages) == ["Rules", "Go north"]
+
+
+def test_stub_llm_client_returns_queued_replies(stub_llm_client: StubLLMClient) -> None:
+    stub_llm_client.enqueue_reply("First")
+    stub_llm_client.enqueue_reply("Second")
+
+    response_one = stub_llm_client.complete([LLMMessage(role="user", content="Hi")])
+    response_two = stub_llm_client.complete([LLMMessage(role="user", content="Again")])
+
+    assert response_one.message.content == "First"
+    assert response_two.message.content == "Second"
+    assert [call[-1].content for call in stub_llm_client.calls] == ["Hi", "Again"]


### PR DESCRIPTION
## Summary
- add a reusable `StubLLMClient` fixture that records calls and replays queued replies for tests
- update the LLM test suite to exercise the stub fixture and ensure deterministic behaviour
- document the new fixture in `TASKS.md`

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8a595997483249b282cc7bfe93b5a