### PR TITLE
Add session persistence module

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -16,7 +16,7 @@ This document captures recommended starting tasks for building out the text-adve
 - [x] Create an initial concrete `StoryEngine` implementation that returns scripted events for testing the loop.
 
 ## Priority 2: Persistence & Memory
-- [ ] Define how game sessions will be persisted (in-memory first, followed by optional file-based persistence).
+- [x] Define how game sessions will be persisted (in-memory first, followed by optional file-based persistence).
 - [ ] Introduce a lightweight memory mechanism so the agent can recall past actions and player choices.
 
 ## Priority 3: Testing & Tooling Enhancements

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -3,6 +3,12 @@
 from .llm import LLMClient, LLMClientError, LLMMessage, LLMResponse, iter_contents
 from .story_engine import StoryChoice, StoryEngine, StoryEvent
 from .scripted_story_engine import ScriptedStoryEngine
+from .persistence import (
+    FileSessionStore,
+    InMemorySessionStore,
+    SessionSnapshot,
+    SessionStore,
+)
 from .world_state import WorldState
 
 __all__ = [
@@ -16,4 +22,8 @@ __all__ = [
     "LLMMessage",
     "LLMResponse",
     "iter_contents",
+    "SessionSnapshot",
+    "SessionStore",
+    "InMemorySessionStore",
+    "FileSessionStore",
 ]

--- a/src/textadventure/persistence.py
+++ b/src/textadventure/persistence.py
@@ -1,0 +1,146 @@
+"""Session persistence utilities for the text adventure framework."""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from .world_state import WorldState
+
+
+@dataclass
+class SessionSnapshot:
+    """Represents the data required to persist a single game session."""
+
+    world_state: WorldState
+
+    def to_payload(self) -> Dict[str, object]:
+        """Return a JSON-serialisable representation of the snapshot."""
+
+        return {
+            "world_state": {
+                "location": self.world_state.location,
+                "inventory": sorted(self.world_state.inventory),
+                "history": list(self.world_state.history),
+            }
+        }
+
+    @classmethod
+    def from_payload(cls, payload: Dict[str, object]) -> "SessionSnapshot":
+        """Build a snapshot from the stored payload representation."""
+
+        world_state_payload = payload.get("world_state")
+        if not isinstance(world_state_payload, dict):
+            raise ValueError("Invalid snapshot payload: missing world_state")
+
+        location = world_state_payload.get("location")
+        inventory = world_state_payload.get("inventory", [])
+        history = world_state_payload.get("history", [])
+
+        if not isinstance(inventory, Iterable) or isinstance(inventory, (str, bytes)):
+            raise ValueError("Invalid snapshot payload: inventory must be iterable")
+        if not isinstance(history, Iterable) or isinstance(history, (str, bytes)):
+            raise ValueError("Invalid snapshot payload: history must be iterable")
+
+        return cls(
+            world_state=WorldState(
+                location=str(location) if location is not None else "starting-area",
+                inventory=set(str(item) for item in inventory),
+                history=[str(event) for event in history],
+            )
+        )
+
+
+class SessionStore(ABC):
+    """Interface describing how session snapshots are persisted."""
+
+    @abstractmethod
+    def save(self, session_id: str, snapshot: SessionSnapshot) -> None:
+        """Persist the snapshot for later retrieval."""
+
+    @abstractmethod
+    def load(self, session_id: str) -> SessionSnapshot:
+        """Return the snapshot for the given session.
+
+        Raises:
+            KeyError: If the session cannot be found.
+        """
+
+    @abstractmethod
+    def delete(self, session_id: str) -> None:
+        """Remove the stored snapshot if it exists."""
+
+    @abstractmethod
+    def list_sessions(self) -> List[str]:
+        """Return all session identifiers stored in this persistence layer."""
+
+
+class InMemorySessionStore(SessionStore):
+    """Keep session snapshots in local process memory."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, SessionSnapshot] = {}
+
+    def save(self, session_id: str, snapshot: SessionSnapshot) -> None:
+        self._sessions[_validate_session_id(session_id)] = snapshot
+
+    def load(self, session_id: str) -> SessionSnapshot:
+        key = _validate_session_id(session_id)
+        try:
+            return self._sessions[key]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise KeyError(f"Session '{session_id}' does not exist") from exc
+
+    def delete(self, session_id: str) -> None:
+        key = _validate_session_id(session_id)
+        self._sessions.pop(key, None)
+
+    def list_sessions(self) -> List[str]:
+        return sorted(self._sessions.keys())
+
+
+class FileSessionStore(SessionStore):
+    """Persist session snapshots as JSON files on disk."""
+
+    def __init__(self, storage_dir: Path) -> None:
+        self.storage_dir = storage_dir
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
+
+    def save(self, session_id: str, snapshot: SessionSnapshot) -> None:
+        session_file = self._session_path(session_id)
+        session_file.write_text(json.dumps(snapshot.to_payload(), indent=2), encoding="utf-8")
+
+    def load(self, session_id: str) -> SessionSnapshot:
+        session_file = self._session_path(session_id)
+        if not session_file.exists():
+            raise KeyError(f"Session '{session_id}' does not exist")
+        payload = json.loads(session_file.read_text(encoding="utf-8"))
+        return SessionSnapshot.from_payload(payload)
+
+    def delete(self, session_id: str) -> None:
+        session_file = self._session_path(session_id)
+        if session_file.exists():
+            session_file.unlink()
+
+    def list_sessions(self) -> List[str]:
+        return sorted(
+            session_path.stem
+            for session_path in self.storage_dir.glob("*.json")
+            if session_path.is_file()
+        )
+
+    def _session_path(self, session_id: str) -> Path:
+        validated = _validate_session_id(session_id)
+        return self.storage_dir / f"{validated}.json"
+
+
+def _validate_session_id(session_id: str) -> str:
+    if not isinstance(session_id, str):
+        raise TypeError("session_id must be a string")
+    stripped = session_id.strip()
+    if not stripped:
+        raise ValueError("session_id must be a non-empty string")
+    return stripped

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,96 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from textadventure import (
+    FileSessionStore,
+    InMemorySessionStore,
+    SessionSnapshot,
+    WorldState,
+)
+
+
+@pytest.fixture
+def sample_snapshot() -> SessionSnapshot:
+    return SessionSnapshot(
+        world_state=WorldState(
+            location="mysterious-cave",
+            inventory={"torch", "map"},
+            history=["Woke up.", "Picked up torch.", "Studied the map."],
+        )
+    )
+
+
+def test_in_memory_session_store_round_trip(sample_snapshot: SessionSnapshot) -> None:
+    store = InMemorySessionStore()
+    store.save("session-1", sample_snapshot)
+
+    retrieved = store.load("session-1")
+    assert retrieved is sample_snapshot
+    assert store.list_sessions() == ["session-1"]
+
+    store.delete("session-1")
+    assert store.list_sessions() == []
+    with pytest.raises(KeyError):
+        store.load("session-1")
+
+
+def test_in_memory_session_store_validates_identifier(sample_snapshot: SessionSnapshot) -> None:
+    store = InMemorySessionStore()
+    with pytest.raises(ValueError):
+        store.save("   ", sample_snapshot)
+    with pytest.raises(TypeError):
+        store.save(123, sample_snapshot)  # type: ignore[arg-type]
+
+
+def test_file_session_store_round_trip(tmp_path: Path, sample_snapshot: SessionSnapshot) -> None:
+    store = FileSessionStore(tmp_path)
+    store.save("my-session", sample_snapshot)
+
+    retrieved = store.load("my-session")
+    assert retrieved.world_state.location == sample_snapshot.world_state.location
+    assert retrieved.world_state.inventory == sample_snapshot.world_state.inventory
+    assert retrieved.world_state.history == sample_snapshot.world_state.history
+
+    listing_before_delete = store.list_sessions()
+    assert listing_before_delete == ["my-session"]
+
+    store.delete("my-session")
+    assert store.list_sessions() == []
+    with pytest.raises(KeyError):
+        store.load("my-session")
+
+
+def test_file_session_store_persists_json(tmp_path: Path, sample_snapshot: SessionSnapshot) -> None:
+    store = FileSessionStore(tmp_path)
+    store.save("persisted", sample_snapshot)
+
+    payload = json.loads((tmp_path / "persisted.json").read_text(encoding="utf-8"))
+    assert payload["world_state"]["location"] == "mysterious-cave"
+    assert sorted(payload["world_state"]["inventory"]) == ["map", "torch"]
+    assert payload["world_state"]["history"] == sample_snapshot.world_state.history
+
+
+def test_snapshot_from_payload_validates() -> None:
+    with pytest.raises(ValueError):
+        SessionSnapshot.from_payload({})
+
+    with pytest.raises(ValueError):
+        SessionSnapshot.from_payload({"world_state": {"inventory": "not-iterable"}})
+
+    with pytest.raises(ValueError):
+        SessionSnapshot.from_payload({"world_state": {"history": "not-iterable"}})
+
+    snapshot = SessionSnapshot.from_payload(
+        {
+            "world_state": {
+                "location": "forest",
+                "inventory": ["staff"],
+                "history": ["Started."],
+            }
+        }
+    )
+    assert snapshot.world_state.location == "forest"
+    assert snapshot.world_state.inventory == {"staff"}
+    assert snapshot.world_state.history == ["Started."]


### PR DESCRIPTION
## Summary
- add a persistence module with abstractions for session snapshots plus in-memory and file-backed stores
- expose the new persistence utilities via the package init for easy imports
- cover the persistence behaviour with unit tests and document the completed backlog item

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8a6ceb97483249b6293993962dbd0