### PR TITLE
Add memory log and recall command to adventure

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -17,7 +17,7 @@ This document captures recommended starting tasks for building out the text-adve
 
 ## Priority 2: Persistence & Memory
 - [x] Define how game sessions will be persisted (in-memory first, followed by optional file-based persistence).
-- [ ] Introduce a lightweight memory mechanism so the agent can recall past actions and player choices.
+- [x] Introduce a lightweight memory mechanism so the agent can recall past actions and player choices. *(Implemented `MemoryLog` utilities, wired into the world state, and surfaced via a scripted "recall" command.)*
 
 ## Priority 3: Testing & Tooling Enhancements
 - [x] Write unit tests covering the world state mutations and narrative branching logic.

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ def run_cli(engine: StoryEngine, world: WorldState) -> None:
     print("Type 'quit' at any time to end the session.\n")
 
     event = engine.propose_event(world)
+    world.remember_observation(event.narration)
     while True:
         print(engine.format_event(event))
         if not event.has_choices:
@@ -38,7 +39,9 @@ def run_cli(engine: StoryEngine, world: WorldState) -> None:
             print("\nThanks for playing!")
             break
 
+        world.remember_action(player_input)
         event = engine.propose_event(world, player_input=player_input)
+        world.remember_observation(event.narration)
 
 
 def main() -> None:

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -9,6 +9,7 @@ from .persistence import (
     SessionSnapshot,
     SessionStore,
 )
+from .memory import MemoryEntry, MemoryLog
 from .world_state import WorldState
 
 __all__ = [
@@ -17,6 +18,8 @@ __all__ = [
     "StoryEvent",
     "StoryEngine",
     "ScriptedStoryEngine",
+    "MemoryEntry",
+    "MemoryLog",
     "LLMClient",
     "LLMClientError",
     "LLMMessage",

--- a/src/textadventure/memory.py
+++ b/src/textadventure/memory.py
@@ -1,0 +1,102 @@
+"""Lightweight memory utilities for tracking player actions and observations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Iterator, List, Sequence, Tuple
+
+
+def _validate_text(value: str, *, field_name: str) -> str:
+    """Normalise and validate free-form text fields."""
+
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string, got {type(value)!r}")
+
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return stripped
+
+
+@dataclass(frozen=True)
+class MemoryEntry:
+    """Represents a single memory captured by the adventure agent."""
+
+    kind: str
+    content: str
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+
+
+class MemoryLog:
+    """Store and retrieve structured memories about the session."""
+
+    def __init__(self) -> None:
+        self._entries: List[MemoryEntry] = []
+
+    def remember(
+        self, kind: str, content: str, *, tags: Iterable[str] | None = None
+    ) -> MemoryEntry:
+        """Record a new memory and return the stored entry."""
+
+        normalised_kind = _validate_text(kind, field_name="kind").lower()
+        normalised_content = _validate_text(content, field_name="content")
+
+        normalised_tags: Tuple[str, ...]
+        if tags is None:
+            normalised_tags = ()
+        else:
+            unique_tags: List[str] = []
+            for tag in tags:
+                validated = _validate_text(tag, field_name="tag").lower()
+                if validated not in unique_tags:
+                    unique_tags.append(validated)
+            normalised_tags = tuple(unique_tags)
+
+        entry = MemoryEntry(
+            kind=normalised_kind,
+            content=normalised_content,
+            tags=normalised_tags,
+        )
+        self._entries.append(entry)
+        return entry
+
+    def recent(
+        self, *, kind: str | None = None, limit: int | None = None
+    ) -> Sequence[MemoryEntry]:
+        """Return the most recent memories optionally filtered by ``kind``."""
+
+        if limit is not None and limit < 0:
+            raise ValueError("limit must be non-negative when provided")
+
+        filtered = [
+            entry
+            for entry in self._entries
+            if kind is None or entry.kind == kind.lower()
+        ]
+        if limit is None:
+            return tuple(filtered)
+
+        if limit == 0:
+            return ()
+
+        return tuple(filtered[-limit:])
+
+    def find_by_tag(self, tag: str) -> Sequence[MemoryEntry]:
+        """Return memories tagged with the provided keyword."""
+
+        normalised_tag = _validate_text(tag, field_name="tag").lower()
+        return tuple(entry for entry in self._entries if normalised_tag in entry.tags)
+
+    def clear(self) -> None:
+        """Remove all stored memories."""
+
+        self._entries.clear()
+
+    def __len__(self) -> int:  # pragma: no cover - trivial delegation
+        return len(self._entries)
+
+    def __iter__(self) -> Iterator[MemoryEntry]:  # pragma: no cover
+        return iter(self._entries)
+
+
+__all__ = ["MemoryEntry", "MemoryLog"]

--- a/src/textadventure/scripted_story_engine.py
+++ b/src/textadventure/scripted_story_engine.py
@@ -46,6 +46,15 @@ def _inventory_summary(world_state: WorldState) -> str:
     return f"Your pack currently holds: {items}."
 
 
+def _memory_summary(world_state: WorldState) -> str:
+    recent_actions = world_state.recent_actions()
+    if not recent_actions:
+        return "You search your thoughts but recall no deliberate choices yet."
+
+    entries = "\n".join(f"- {action}" for action in recent_actions)
+    return f"You reflect on your recent decisions:\n{entries}"
+
+
 class ScriptedStoryEngine(StoryEngine):
     """A deterministic `StoryEngine` with two handcrafted locations."""
 
@@ -86,6 +95,12 @@ class ScriptedStoryEngine(StoryEngine):
         if command == "inventory":
             return StoryEvent(
                 narration=_inventory_summary(world_state),
+                choices=scene.choices,
+            )
+
+        if command == "recall":
+            return StoryEvent(
+                narration=_memory_summary(world_state),
                 choices=scene.choices,
             )
 
@@ -131,6 +146,7 @@ _DEFAULT_SCENES: MutableMapping[str, _Scene] = {
             StoryChoice("explore", "Head toward the mossy gate."),
             StoryChoice("inventory", "Check what you're carrying."),
             StoryChoice("journal", "Review the notes in your journal."),
+            StoryChoice("recall", "Reflect on your recent decisions."),
         ),
         transitions={
             "look": _Transition(
@@ -153,6 +169,7 @@ _DEFAULT_SCENES: MutableMapping[str, _Scene] = {
             StoryChoice("return", "Head back down the forest trail."),
             StoryChoice("inventory", "Check your belongings."),
             StoryChoice("journal", "Look over your recorded memories."),
+            StoryChoice("recall", "Reflect on your recent decisions."),
         ),
         transitions={
             "look": _Transition(

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,41 @@
+"""Tests for the lightweight memory utilities."""
+
+from textadventure.memory import MemoryLog
+
+
+def test_remember_normalises_fields() -> None:
+    log = MemoryLog()
+    entry = log.remember("Action", "  Open the Door  ", tags=["Door", "door"])
+
+    assert entry.kind == "action"
+    assert entry.content == "Open the Door"
+    assert entry.tags == ("door",)
+    assert log.recent() == (entry,)
+
+
+def test_recent_filters_by_kind_and_limit() -> None:
+    log = MemoryLog()
+    log.remember("action", "Open door")
+    log.remember("observation", "You see a hallway")
+    log.remember("action", "Step inside")
+
+    actions = log.recent(kind="action", limit=2)
+
+    assert [entry.content for entry in actions] == ["Open door", "Step inside"]
+
+
+def test_recent_with_zero_limit_returns_empty() -> None:
+    log = MemoryLog()
+    log.remember("action", "Knock")
+
+    assert log.recent(limit=0) == ()
+
+
+def test_find_by_tag_matches_case_insensitively() -> None:
+    log = MemoryLog()
+    first = log.remember("action", "Inspect the altar", tags=["clue"])
+    log.remember("action", "Look around", tags=["scenery"])
+
+    matches = log.find_by_tag("Clue")
+
+    assert matches == (first,)

--- a/tests/test_scripted_story_engine.py
+++ b/tests/test_scripted_story_engine.py
@@ -13,7 +13,9 @@ def test_initial_event_describes_location() -> None:
     event = engine.propose_event(world)
 
     assert "trailhead" in event.narration
-    assert "look" in event.iter_choice_commands()
+    commands = event.iter_choice_commands()
+    assert "look" in commands
+    assert "recall" in commands
 
 
 def test_explore_transitions_to_gate() -> None:
@@ -47,3 +49,17 @@ def test_unknown_command_reprompts() -> None:
 
     assert "not sure" in event.narration.lower()
     assert "dance" in event.narration
+
+
+def test_recall_command_reports_recent_actions() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    world.remember_action("look")
+    world.remember_action("explore the gate")
+
+    event = engine.propose_event(world, player_input="recall")
+
+    assert "reflect on your recent decisions" in event.narration.lower()
+    assert "look" in event.narration
+    assert "explore the gate" in event.narration

--- a/tests/test_world_state.py
+++ b/tests/test_world_state.py
@@ -58,3 +58,16 @@ def test_remove_item_returns_false_when_absent(world_state: WorldState) -> None:
 
     assert result is False
     assert world_state.history == []
+
+
+def test_recent_actions_reflect_recorded_memory(world_state: WorldState) -> None:
+    world_state.remember_action("Open the gate")
+    world_state.remember_action("Step through")
+
+    assert world_state.recent_actions() == ("Open the gate", "Step through")
+
+
+def test_recent_observations_reflect_story_notes(world_state: WorldState) -> None:
+    world_state.remember_observation("A lantern flickers in the dusk.")
+
+    assert world_state.recent_observations(limit=1) == ("A lantern flickers in the dusk.",)


### PR DESCRIPTION
## Summary
- add a reusable MemoryLog for storing player actions and story observations in the world state
- extend the scripted engine and CLI loop to populate memory and surface a new recall command
- cover the memory utilities and recall flow with dedicated tests and update the task backlog

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8ac00daf8832497d6ba7eca35ff14