### PR TITLE
Ensure linting commands run cleanly

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -6,7 +6,7 @@ This document captures recommended starting tasks for building out the text-adve
 - [x] Create a minimal `src/main.py` entry point that can be executed after dependency installation.
 - [x] Configure a package structure under `src/` (e.g., `src/textadventure/__init__.py`).
 - [x] Add basic test scaffolding in `tests/` (at least one placeholder test verifying the package imports).
-- [ ] Confirm linting and formatting commands (`black`, `ruff`) run cleanly on the scaffolded code.
+- [x] Confirm linting and formatting commands (`black`, `ruff`) run cleanly on the scaffolded code. *(Added `pytest.ini` to expose the `src/` layout and reformatted existing modules so Black and Ruff both pass.)*
 
 ## Priority 1: Core Framework Skeleton
 - [x] Implement a `WorldState` object responsible for tracking locations, inventory, and history.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/textadventure/persistence.py
+++ b/src/textadventure/persistence.py
@@ -111,7 +111,9 @@ class FileSessionStore(SessionStore):
 
     def save(self, session_id: str, snapshot: SessionSnapshot) -> None:
         session_file = self._session_path(session_id)
-        session_file.write_text(json.dumps(snapshot.to_payload(), indent=2), encoding="utf-8")
+        session_file.write_text(
+            json.dumps(snapshot.to_payload(), indent=2), encoding="utf-8"
+        )
 
     def load(self, session_id: str) -> SessionSnapshot:
         session_file = self._session_path(session_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,6 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-SRC = ROOT / "src"
-if str(SRC) not in sys.path:
-    sys.path.insert(0, str(SRC))
-
 from collections.abc import Mapping, Sequence
 from typing import Any
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -42,7 +42,9 @@ def test_response_immutability() -> None:
         response.metadata["model"] = "other"  # type: ignore[index]
 
 
-def test_complete_prompt_helper_constructs_user_message(mock_llm_client: "MockLLMClient") -> None:
+def test_complete_prompt_helper_constructs_user_message(
+    mock_llm_client: "MockLLMClient",
+) -> None:
     mock_llm_client.queue_response("Inspecting room")
 
     response = mock_llm_client.complete_prompt("Inspect room", temperature=0.1)
@@ -55,7 +57,9 @@ def test_complete_prompt_helper_constructs_user_message(mock_llm_client: "MockLL
     assert response.message.content == "Inspecting room"
 
 
-def test_mock_llm_client_requires_queued_response(mock_llm_client: "MockLLMClient") -> None:
+def test_mock_llm_client_requires_queued_response(
+    mock_llm_client: "MockLLMClient",
+) -> None:
     with pytest.raises(AssertionError, match="expected a queued response"):
         mock_llm_client.complete([LLMMessage(role="user", content="hello")])
 

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -36,7 +36,9 @@ def test_in_memory_session_store_round_trip(sample_snapshot: SessionSnapshot) ->
         store.load("session-1")
 
 
-def test_in_memory_session_store_validates_identifier(sample_snapshot: SessionSnapshot) -> None:
+def test_in_memory_session_store_validates_identifier(
+    sample_snapshot: SessionSnapshot,
+) -> None:
     store = InMemorySessionStore()
     with pytest.raises(ValueError):
         store.save("   ", sample_snapshot)
@@ -44,7 +46,9 @@ def test_in_memory_session_store_validates_identifier(sample_snapshot: SessionSn
         store.save(123, sample_snapshot)  # type: ignore[arg-type]
 
 
-def test_file_session_store_round_trip(tmp_path: Path, sample_snapshot: SessionSnapshot) -> None:
+def test_file_session_store_round_trip(
+    tmp_path: Path, sample_snapshot: SessionSnapshot
+) -> None:
     store = FileSessionStore(tmp_path)
     store.save("my-session", sample_snapshot)
 
@@ -62,7 +66,9 @@ def test_file_session_store_round_trip(tmp_path: Path, sample_snapshot: SessionS
         store.load("my-session")
 
 
-def test_file_session_store_persists_json(tmp_path: Path, sample_snapshot: SessionSnapshot) -> None:
+def test_file_session_store_persists_json(
+    tmp_path: Path, sample_snapshot: SessionSnapshot
+) -> None:
     store = FileSessionStore(tmp_path)
     store.save("persisted", sample_snapshot)
 

--- a/tests/test_world_state.py
+++ b/tests/test_world_state.py
@@ -70,4 +70,6 @@ def test_recent_actions_reflect_recorded_memory(world_state: WorldState) -> None
 def test_recent_observations_reflect_story_notes(world_state: WorldState) -> None:
     world_state.remember_observation("A lantern flickers in the dusk.")
 
-    assert world_state.recent_observations(limit=1) == ("A lantern flickers in the dusk.",)
+    assert world_state.recent_observations(limit=1) == (
+        "A lantern flickers in the dusk.",
+    )


### PR DESCRIPTION
## Summary
- add a pytest configuration so the src/ layout is automatically discoverable
- remove ad-hoc path manipulation from the pytest fixtures module and rely on configuration
- reformat persistence and test modules with Black to satisfy the linters

## Testing
- ruff check src tests
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8bb814ae483248604fe489ef7b114