### PR TITLE
Add mypy static type checking configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,10 @@ For detailed setup, testing and contribution instructions, see [AGENTS.md](Agent
 2. Install dependencies from `requirements.txt`.
 3. Run the sample driver script under `src/` to launch the game.
 
+## Development Workflow
+
+- Format and lint the codebase with `black` and `ruff` before committing changes.
+- Run the automated tests with `pytest -q`.
+- Check static typing with `mypy` (configuration lives in `mypy.ini`).
+
 We welcome contributions! Please read the contribution guidelines in `AGENTS.md` before submitting pull requests.

--- a/TASKS.md
+++ b/TASKS.md
@@ -22,7 +22,8 @@ This document captures recommended starting tasks for building out the text-adve
 ## Priority 3: Testing & Tooling Enhancements
 - [x] Write unit tests covering the world state mutations and narrative branching logic.
 - [x] Set up fixtures or mocks for LLM interactions to keep tests deterministic. *(Added reusable `MockLLMClient` pytest fixtures for queuing scripted responses.)*
-- [ ] Consider integrating type checking (e.g., `mypy`) and continuous integration workflows (GitHub Actions).
+- [x] Integrate static type checking with `mypy` and document the workflow. *(Added `mypy.ini`, updated developer docs, and
+  tracked the dependency in `requirements.txt`. Setting up CI remains a future improvement.)*
 - [x] Add smoke tests for the CLI once the interactive loop is implemented. *(Introduced `tests/test_cli.py` to simulate player commands and verify graceful termination scenarios.)*
 
 ## Priority 4: Stretch Goals

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+python_version = 3.11
+warn_unused_configs = True
+files = src
+pretty = True
+show_error_codes = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ruff>=0.0.292
 langchain>=0.0.350
 openai>=1.0.0
 python-dotenv>=1.0
+mypy>=1.5.1

--- a/src/textadventure/story_engine.py
+++ b/src/textadventure/story_engine.py
@@ -60,6 +60,7 @@ class StoryEvent:
 
         object.__setattr__(self, "choices", normalised_choices)
 
+        metadata: Mapping[str, str]
         if self.metadata is None:
             metadata = MappingProxyType({})
         else:


### PR DESCRIPTION
## Summary
- add a repository-level mypy configuration and document the new workflow
- include mypy in the dependency list and tighten StoryEvent metadata typing
- update the task backlog to reflect the completed type-checking integration

## Testing
- mypy
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8bcbf3eb883248e84a9f4599d8a06