### PR TITLE
Add knowledge base tool integration for scripted story engine

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -27,7 +27,10 @@ This document captures recommended starting tasks for building out the text-adve
 - [x] Add smoke tests for the CLI once the interactive loop is implemented. *(Introduced `tests/test_cli.py` to simulate player commands and verify graceful termination scenarios.)*
 
 ## Priority 4: Stretch Goals
-- [ ] Explore integrating external tools (e.g., knowledge bases or calculators) the agent can invoke during gameplay.
+- [x] Explore integrating external tools (e.g., knowledge bases or calculators) the agent can invoke during gameplay.
+  - [x] Define a lightweight tool abstraction and document how tools are registered with a story engine.
+  - [x] Provide an initial knowledge-base tool that surfaces lore lookups through scripted commands.
+  - [x] Add automated tests covering the new tool flow and update user-facing guidance where appropriate.
 - [ ] Investigate saving/loading checkpoints for long-running adventures.
 - [ ] Evaluate multi-agent orchestration for NPC behaviors or parallel storylines.
 

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -10,6 +10,7 @@ from .persistence import (
     SessionStore,
 )
 from .memory import MemoryEntry, MemoryLog
+from .tools import KnowledgeBaseTool, Tool, ToolResponse
 from .world_state import WorldState
 
 __all__ = [
@@ -18,6 +19,9 @@ __all__ = [
     "StoryEvent",
     "StoryEngine",
     "ScriptedStoryEngine",
+    "Tool",
+    "ToolResponse",
+    "KnowledgeBaseTool",
     "MemoryEntry",
     "MemoryLog",
     "LLMClient",

--- a/src/textadventure/tools.py
+++ b/src/textadventure/tools.py
@@ -1,0 +1,149 @@
+"""Utility abstractions for tools that support the adventure framework."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Mapping, Sequence, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
+    from .world_state import WorldState
+
+
+def _validate_text(value: str, *, field_name: str) -> str:
+    """Ensure the provided value is a non-empty piece of text."""
+
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string, got {type(value)!r}")
+
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+    return stripped
+
+
+@dataclass(frozen=True)
+class ToolResponse:
+    """Structured response returned by a tool invocation."""
+
+    narration: str
+    metadata: Mapping[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        narration = _validate_text(self.narration, field_name="narration")
+        object.__setattr__(self, "narration", narration)
+
+        if self.metadata is None:
+            metadata: Mapping[str, str] = MappingProxyType({})
+        else:
+            metadata = MappingProxyType(
+                {
+                    _validate_text(str(key), field_name="metadata key"): _validate_text(
+                        str(value), field_name="metadata value"
+                    )
+                    for key, value in self.metadata.items()
+                }
+            )
+        object.__setattr__(self, "metadata", metadata)
+
+
+class Tool(ABC):
+    """Base class for utilities that the story engine can invoke."""
+
+    def __init__(self, name: str, description: str) -> None:
+        self._name = _validate_text(name, field_name="tool name")
+        self._description = _validate_text(description, field_name="tool description")
+
+    @property
+    def name(self) -> str:
+        """Human-readable identifier for the tool."""
+
+        return self._name
+
+    @property
+    def description(self) -> str:
+        """Summary of what the tool can do."""
+
+        return self._description
+
+    @abstractmethod
+    def invoke(self, query: str, *, world_state: WorldState) -> ToolResponse:
+        """Execute the tool with the provided query and world context."""
+
+    def usage_hints(self) -> Sequence[str]:
+        """Return optional usage hints for the tool."""
+
+        return ()
+
+
+class KnowledgeBaseTool(Tool):
+    """Simple lookup tool backed by a static mapping of lore entries."""
+
+    def __init__(
+        self,
+        entries: Mapping[str, str],
+        *,
+        name: str = "Field Guide",
+        description: str = "Provides lore snippets about notable topics.",
+    ) -> None:
+        if not entries:
+            raise ValueError("entries must contain at least one topic")
+
+        super().__init__(name=name, description=description)
+
+        normalised: dict[str, str] = {}
+        for topic, text in entries.items():
+            key = _validate_text(topic, field_name="topic name").lower()
+            value = _validate_text(text, field_name="topic entry")
+            if key in normalised:
+                raise ValueError(f"duplicate topic provided: {topic!r}")
+            normalised[key] = value
+
+        self._entries: Mapping[str, str] = MappingProxyType(normalised)
+
+    def available_topics(self) -> Sequence[str]:
+        """Return the list of topics this knowledge base understands."""
+
+        return tuple(sorted(self._entries.keys()))
+
+    def usage_hints(self) -> Sequence[str]:  # pragma: no cover - trivial delegation
+        topics = self.available_topics()
+        if not topics:
+            return ()
+        return ("Try topics like: " + ", ".join(topics),)
+
+    def invoke(self, query: str, *, world_state: WorldState) -> ToolResponse:
+        del world_state  # The static knowledge base does not currently inspect it.
+
+        cleaned_query = query.strip().lower()
+        if not cleaned_query:
+            hints = self.usage_hints()
+            hint_text = "\n".join(hints) if hints else "Try specifying a topic name."
+            return ToolResponse(
+                narration=(
+                    "You flip through the field guide but need a topic to look up.\n"
+                    f"{hint_text}"
+                ),
+                metadata={"tool": self.name, "status": "missing_query"},
+            )
+
+        entry = self._entries.get(cleaned_query)
+        if entry is None:
+            hints = self.usage_hints()
+            hint_text = "\n".join(hints) if hints else "No additional topics are listed."
+            return ToolResponse(
+                narration=(
+                    f"The field guide has no entry for '{cleaned_query}'.\n{hint_text}"
+                ),
+                metadata={"tool": self.name, "status": "not_found", "topic": cleaned_query},
+            )
+
+        return ToolResponse(
+            narration=entry,
+            metadata={"tool": self.name, "status": "ok", "topic": cleaned_query},
+        )
+
+
+__all__ = ["KnowledgeBaseTool", "Tool", "ToolResponse"]

--- a/tests/test_scripted_story_engine.py
+++ b/tests/test_scripted_story_engine.py
@@ -63,3 +63,24 @@ def test_recall_command_reports_recent_actions() -> None:
     assert "reflect on your recent decisions" in event.narration.lower()
     assert "look" in event.narration
     assert "explore the gate" in event.narration
+
+
+def test_tool_command_returns_lore_entry() -> None:
+    world = WorldState(location="old-gate")
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world, player_input="guide gate")
+
+    assert "stone gate" in event.narration.lower()
+    assert event.metadata["tool"] == "Field Guide"
+    assert event.metadata["status"] == "ok"
+
+
+def test_tool_command_prompts_for_topic_when_missing_argument() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world, player_input="guide")
+
+    assert "need a topic" in event.narration.lower()
+    assert event.metadata["status"] == "missing_query"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,42 @@
+"""Unit tests for tool abstractions supporting the adventure."""
+
+from __future__ import annotations
+
+import pytest
+
+from textadventure import KnowledgeBaseTool, WorldState
+
+
+def test_knowledge_base_returns_entry_for_known_topic() -> None:
+    tool = KnowledgeBaseTool(entries={"topic": "Detailed lore entry."})
+    world = WorldState()
+
+    response = tool.invoke("topic", world_state=world)
+
+    assert response.narration == "Detailed lore entry."
+    assert response.metadata["status"] == "ok"
+    assert response.metadata["topic"] == "topic"
+
+
+def test_knowledge_base_prompts_for_topic_when_missing() -> None:
+    tool = KnowledgeBaseTool(entries={"topic": "Entry."})
+
+    response = tool.invoke("", world_state=WorldState())
+
+    assert "need a topic" in response.narration.lower()
+    assert response.metadata["status"] == "missing_query"
+
+
+def test_knowledge_base_handles_unknown_topic() -> None:
+    tool = KnowledgeBaseTool(entries={"topic": "Entry."})
+
+    response = tool.invoke("unknown", world_state=WorldState())
+
+    assert "no entry" in response.narration.lower()
+    assert response.metadata["status"] == "not_found"
+    assert response.metadata["topic"] == "unknown"
+
+
+def test_knowledge_base_requires_entries() -> None:
+    with pytest.raises(ValueError):
+        KnowledgeBaseTool(entries={})


### PR DESCRIPTION
## Summary
- add a reusable tool abstraction with a field guide knowledge base implementation
- allow the scripted story engine to invoke registered tools via the new "guide" command
- cover the tool flow with unit tests and update the planning backlog

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8c3295f308324842b9a1d72755e1e