### PR TITLE
Add CLI support for saving and loading sessions

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -31,7 +31,10 @@ This document captures recommended starting tasks for building out the text-adve
   - [x] Define a lightweight tool abstraction and document how tools are registered with a story engine.
   - [x] Provide an initial knowledge-base tool that surfaces lore lookups through scripted commands.
   - [x] Add automated tests covering the new tool flow and update user-facing guidance where appropriate.
-- [ ] Investigate saving/loading checkpoints for long-running adventures.
+- [x] Investigate saving/loading checkpoints for long-running adventures.
+  - [x] Add CLI commands to save and load sessions using the persistence layer.
+  - [x] Extend persistence snapshots to cover memory and provide helpers for applying them.
+  - [x] Add automated tests demonstrating a save/load round-trip through the CLI.
 - [ ] Evaluate multi-agent orchestration for NPC behaviors or parallel storylines.
 
 Revisit this backlog as soon as the initial scaffolding is in place so we can refine upcoming milestones based on early feedback.

--- a/src/main.py
+++ b/src/main.py
@@ -1,19 +1,56 @@
-"""Entry point for the text adventure prototype."""
+"""Command-line entry point for the text adventure prototype."""
 
 from __future__ import annotations
 
-from textadventure import StoryEngine, WorldState
+import argparse
+from pathlib import Path
+from typing import Sequence
+
+from textadventure import (
+    FileSessionStore,
+    SessionSnapshot,
+    SessionStore,
+    StoryEngine,
+    WorldState,
+)
 from textadventure.scripted_story_engine import ScriptedStoryEngine
 
 
-def run_cli(engine: StoryEngine, world: WorldState) -> None:
+def run_cli(
+    engine: StoryEngine,
+    world: WorldState,
+    *,
+    session_store: SessionStore | None = None,
+    autoload_session: str | None = None,
+) -> None:
     """Drive a very small interactive loop using ``input``/``print``."""
 
     print("Welcome to the Text Adventure prototype!")
-    print("Type 'quit' at any time to end the session.\n")
+    print("Type 'quit' at any time to end the session.")
+    if session_store is not None:
+        print("Type 'save <name>' or 'load <name>' to manage checkpoints.\n")
+    else:
+        print()
 
-    event = engine.propose_event(world)
-    world.remember_observation(event.narration)
+    event = None
+    if session_store is not None and autoload_session:
+        try:
+            snapshot = session_store.load(autoload_session)
+        except KeyError:
+            print(
+                f"No saved session named '{autoload_session}' was found. "
+                "Starting a new adventure.\n"
+            )
+        else:
+            snapshot.apply_to_world(world)
+            print(f"Loaded session '{autoload_session}'.\n")
+            event = engine.propose_event(world)
+            world.remember_observation(event.narration)
+
+    if event is None:
+        event = engine.propose_event(world)
+        world.remember_observation(event.narration)
+
     while True:
         print(engine.format_event(event))
         if not event.has_choices:
@@ -34,22 +71,89 @@ def run_cli(engine: StoryEngine, world: WorldState) -> None:
             event = engine.propose_event(world)
             continue
 
+        command, _, argument = player_input.partition(" ")
+        command_lower = command.lower()
         lowered = player_input.lower()
         if lowered in {"quit", "exit"}:
             print("\nThanks for playing!")
             break
+
+        if command_lower == "save":
+            if session_store is None:
+                print("\nSession persistence is not configured. Saving is unavailable.")
+            else:
+                session_id = argument.strip()
+                if not session_id:
+                    print("\nUsage: save <session-id>")
+                else:
+                    session_store.save(session_id, SessionSnapshot.capture(world))
+                    print(f"\nSaved session '{session_id}'.")
+            continue
+
+        if command_lower == "load":
+            if session_store is None:
+                print("\nSession persistence is not configured. Loading is unavailable.")
+            else:
+                session_id = argument.strip()
+                if not session_id:
+                    print("\nUsage: load <session-id>")
+                else:
+                    try:
+                        snapshot = session_store.load(session_id)
+                    except KeyError:
+                        print(f"\nNo saved session named '{session_id}' was found.")
+                    else:
+                        snapshot.apply_to_world(world)
+                        print(f"\nLoaded session '{session_id}'.")
+                        event = engine.propose_event(world)
+                        world.remember_observation(event.narration)
+            continue
 
         world.remember_action(player_input)
         event = engine.propose_event(world, player_input=player_input)
         world.remember_observation(event.narration)
 
 
-def main() -> None:
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Text Adventure prototype")
+    parser.add_argument(
+        "--session-dir",
+        type=Path,
+        default=Path("sessions"),
+        help="Directory used to store saved sessions (default: ./sessions).",
+    )
+    parser.add_argument(
+        "--session-id",
+        type=str,
+        help="Session identifier to load on startup if it exists.",
+    )
+    parser.add_argument(
+        "--no-persistence",
+        action="store_true",
+        help="Disable session persistence commands for this run.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
     """Start the scripted demo adventure."""
 
+    args = _parse_args(argv)
     world = WorldState()
     engine = ScriptedStoryEngine()
-    run_cli(engine, world)
+
+    session_store: SessionStore | None = None
+    autoload_session: str | None = None
+    if not args.no_persistence:
+        session_store = FileSessionStore(args.session_dir)
+        autoload_session = args.session_id
+    elif args.session_id:
+        print(
+            "--session-id was provided but persistence is disabled. "
+            "The adventure will start fresh."
+        )
+
+    run_cli(engine, world, session_store=session_store, autoload_session=autoload_session)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add CLI commands for saving, loading, and autoloading sessions plus argument parsing for persistence options
- extend session snapshots to persist memory data and provide helpers for cloning and applying saved state
- add coverage for the new persistence flow in CLI and persistence tests and mark the roadmap item as complete

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8c460fd9c8324a4abb5ad36aa95f7