### PR TITLE
Externalize scripted story scenes into JSON data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository hosts an experimental text-adventure framework that explores how
 
 - **World modelling** – `WorldState` tracks locations, actors, inventory, memories, and player actions.
 - **Story engines** – the `StoryEngine` protocol defines how narrative beats are proposed; the included `ScriptedStoryEngine` delivers a deterministic storyline that is easy to extend.
+- **Data-driven demo scenes** – the sample adventure reads its locations from `textadventure/data/scripted_scenes.json`, making narrative tweaks possible without touching Python code.
 - **Multi-agent orchestration** – `MultiAgentCoordinator` lets several agents (LLM-backed or scripted) take turns responding to the player.
 - **Session persistence** – `FileSessionStore` enables save/load checkpoints directly from the CLI demo.
 - **Tooling hooks** – `KnowledgeBaseTool` and base `Tool` interfaces illustrate how agents can extend their capabilities.
@@ -21,6 +22,8 @@ src/
     memory.py            # Memory log utilities
     multi_agent.py       # Agent coordination primitives
     persistence.py       # Session snapshot + storage helpers
+    data/
+      scripted_scenes.json  # Bundled demo adventure definition
     scripted_story_engine.py
     story_engine.py      # Story event interfaces
     tools.py             # Tool interface & knowledge base example
@@ -46,6 +49,26 @@ Additional project planning notes live in [`TASKS.md`](TASKS.md).
    python src/main.py
    ```
    Use `python src/main.py --help` to discover save/load options.
+
+## Customising the Demo Adventure
+
+The bundled `ScriptedStoryEngine` now loads its scenes from the JSON file at
+`textadventure/data/scripted_scenes.json`. Copy that file to craft new
+locations, choices, and transitions, then load it with
+`textadventure.load_scenes_from_file` when constructing a custom engine:
+
+```python
+from textadventure import ScriptedStoryEngine, WorldState, load_scenes_from_file
+
+scenes = load_scenes_from_file("my_custom_adventure.json")
+engine = ScriptedStoryEngine(scenes=scenes)
+
+world = WorldState()
+print(engine.propose_event(world).narration)
+```
+
+Running the CLI with this engine lets designers iterate on adventures without
+changing the Python source.
 
 ## Testing and Quality Checks
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -45,7 +45,10 @@ This document captures recommended starting tasks for building out the text-adve
 Revisit this backlog as soon as the initial scaffolding is in place so we can refine upcoming milestones based on early feedback.
 
 ## Priority 5: Data-Driven Narrative Expansion
-- [ ] Externalise the scripted scenes into structured data files (e.g., YAML or JSON) so adventures can be edited without touching code while retaining sensible defaults for the demo.
+- [x] Externalise the scripted scenes into structured data files (e.g., YAML or JSON) so adventures can be edited without touching code while retaining sensible defaults for the demo.
+  - [x] Extract the current hard-coded demo scenes into a reusable data file checked into the repo.
+  - [x] Update `ScriptedStoryEngine` so it can load scenes from structured data and still provide a default demo set.
+  - [x] Refresh tests and docs to cover the data-driven scene workflow.
 - [ ] Add validation helpers that load the scene definitions, ensure commands are unique, verify transition targets exist, and surface descriptive errors with unit tests.
 - [ ] Document the data format and authoring workflow in `docs/` and update the README so contributors can build new adventures quickly.
 

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -2,7 +2,11 @@
 
 from .llm import LLMClient, LLMClientError, LLMMessage, LLMResponse, iter_contents
 from .story_engine import StoryChoice, StoryEngine, StoryEvent
-from .scripted_story_engine import ScriptedStoryEngine
+from .scripted_story_engine import (
+    ScriptedStoryEngine,
+    load_scenes_from_file,
+    load_scenes_from_mapping,
+)
 from .multi_agent import (
     Agent,
     AgentTrigger,
@@ -26,6 +30,8 @@ __all__ = [
     "StoryEvent",
     "StoryEngine",
     "ScriptedStoryEngine",
+    "load_scenes_from_file",
+    "load_scenes_from_mapping",
     "Agent",
     "AgentTrigger",
     "AgentTurnResult",

--- a/src/textadventure/data/__init__.py
+++ b/src/textadventure/data/__init__.py
@@ -1,0 +1,3 @@
+"""Data assets bundled with the text adventure package."""
+
+__all__ = []

--- a/src/textadventure/data/scripted_scenes.json
+++ b/src/textadventure/data/scripted_scenes.json
@@ -1,0 +1,53 @@
+{
+  "starting-area": {
+    "description": "Sunlight filters through tall trees at the forest trailhead. An old stone gate lies to the north, its archway draped in moss.",
+    "choices": [
+      {"command": "look", "description": "Take in the surroundings."},
+      {"command": "explore", "description": "Head toward the mossy gate."},
+      {"command": "inventory", "description": "Check what you're carrying."},
+      {"command": "journal", "description": "Review the notes in your journal."},
+      {"command": "recall", "description": "Reflect on your recent decisions."},
+      {
+        "command": "guide",
+        "description": "Consult the field guide for lore (e.g. 'guide gate')."
+      }
+    ],
+    "transitions": {
+      "look": {
+        "narration": "You pause and listen to the rustling leaves."
+      },
+      "explore": {
+        "narration": "You follow the worn path toward the gate.",
+        "target": "old-gate"
+      }
+    }
+  },
+  "old-gate": {
+    "description": "The gate stands ajar, revealing a courtyard blanketed in mist. A rusty key glints between the stones nearby.",
+    "choices": [
+      {"command": "look", "description": "Study the ancient masonry."},
+      {"command": "inspect", "description": "Investigate the glinting object."},
+      {"command": "return", "description": "Head back down the forest trail."},
+      {"command": "inventory", "description": "Check your belongings."},
+      {"command": "journal", "description": "Look over your recorded memories."},
+      {"command": "recall", "description": "Reflect on your recent decisions."},
+      {
+        "command": "guide",
+        "description": "Consult the field guide for lore (e.g. 'guide gate')."
+      }
+    ],
+    "transitions": {
+      "look": {
+        "narration": "Time has scarred the gate, but it still stands firm."
+      },
+      "inspect": {
+        "narration": "You kneel and pick up the rusty key.",
+        "item": "rusty key"
+      },
+      "return": {
+        "narration": "You retrace your steps to the trailhead.",
+        "target": "starting-area"
+      }
+    }
+  }
+}

--- a/tests/test_scripted_story_engine.py
+++ b/tests/test_scripted_story_engine.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from importlib import resources
+
 from textadventure import WorldState
-from textadventure.scripted_story_engine import ScriptedStoryEngine
+from textadventure.scripted_story_engine import (
+    ScriptedStoryEngine,
+    load_scenes_from_file,
+)
 
 
 def test_initial_event_describes_location() -> None:
@@ -84,3 +89,15 @@ def test_tool_command_prompts_for_topic_when_missing_argument() -> None:
 
     assert "need a topic" in event.narration.lower()
     assert event.metadata["status"] == "missing_query"
+
+
+def test_load_scenes_from_file_matches_default() -> None:
+    data_path = resources.files("textadventure.data").joinpath("scripted_scenes.json")
+    scenes = load_scenes_from_file(str(data_path))
+    world = WorldState()
+    engine = ScriptedStoryEngine(scenes=scenes)
+
+    event = engine.propose_event(world)
+
+    assert "trailhead" in event.narration
+    assert "guide" in event.iter_choice_commands()


### PR DESCRIPTION
## Summary
- move the demo adventure scenes into a bundled JSON data file and expose scene loading helpers
- update `ScriptedStoryEngine` to hydrate scenes from structured data while keeping knowledge-base tools intact
- refresh documentation, tests, and the task list to cover the new data-driven workflow

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8d010e154832485eaebe6fd97e245