### PR TITLE
Add CLI status command and coordinator debug snapshot

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -61,5 +61,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
 
 ## Priority 7: Observability & Tooling
 - [ ] Add transcript logging options to the CLI (e.g., `--log-file`) that capture narration, player input, and agent metadata for debugging sessions.
-- [ ] Introduce a debug command (such as `status`) that prints the active location, inventory summary, queued agent messages, and pending saves.
+- [x] Introduce a debug command (such as `status`) that prints the active location, inventory summary, queued agent messages, and pending saves.
+  - [x] Provide a coordinator debug snapshot with visibility into queued messages.
+  - [x] Surface the world/persistence details through a CLI `status` command and cover it with tests.
 - [ ] Set up a continuous integration workflow (GitHub Actions) to run tests, type checks, and linting on each push.

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -11,7 +11,9 @@ from .multi_agent import (
     Agent,
     AgentTrigger,
     AgentTurnResult,
+    CoordinatorDebugState,
     MultiAgentCoordinator,
+    QueuedAgentMessage,
     ScriptedStoryAgent,
 )
 from .persistence import (
@@ -37,6 +39,8 @@ __all__ = [
     "AgentTurnResult",
     "ScriptedStoryAgent",
     "MultiAgentCoordinator",
+    "CoordinatorDebugState",
+    "QueuedAgentMessage",
     "Tool",
     "ToolResponse",
     "KnowledgeBaseTool",


### PR DESCRIPTION
## Summary
- add debug snapshot dataclasses to the multi-agent coordinator so queued messages can be inspected safely
- implement a CLI `status` command that surfaces location, inventory, queued agent messages, and available saves
- cover the new diagnostics with targeted unit tests and expose the debug types via the public package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8d89350b08324b4d82735e8b13086