### PR TITLE
Add LLM-backed story agent

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -55,7 +55,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
 - [x] Document the data format and authoring workflow in `docs/` and update the README so contributors can build new adventures quickly. *(Added `docs/data_driven_scenes.md` and linked guidance from the README.)*
 
 ## Priority 6: Generative Agent Integration
-- [ ] Implement an `LLMStoryAgent` that wraps `LLMClient`, assembles prompts from the world state, and can participate in the `MultiAgentCoordinator` turn loop.
+- [x] Implement an `LLMStoryAgent` that wraps `LLMClient`, assembles prompts from the world state, and can participate in the `MultiAgentCoordinator` turn loop.
+  - [x] Build a structured prompt generator that summarises the world state and trigger context for the LLM.
+  - [x] Parse JSON responses from the LLM into `StoryEvent` instances with validation.
+  - [x] Cover the agent with unit tests demonstrating prompt construction and error handling.
 - [ ] Extend the memory system so agents can request recent observations/actions as part of their prompts, with configuration for how much history to include.
 - [ ] Provide integration tests (or golden transcripts) that exercise a hybrid scripted + LLM-backed coordinator using deterministic fixtures.
 

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -16,6 +16,7 @@ from .multi_agent import (
     QueuedAgentMessage,
     ScriptedStoryAgent,
 )
+from .llm_story_agent import LLMStoryAgent
 from .persistence import (
     FileSessionStore,
     InMemorySessionStore,
@@ -41,6 +42,7 @@ __all__ = [
     "MultiAgentCoordinator",
     "CoordinatorDebugState",
     "QueuedAgentMessage",
+    "LLMStoryAgent",
     "Tool",
     "ToolResponse",
     "KnowledgeBaseTool",

--- a/src/textadventure/llm_story_agent.py
+++ b/src/textadventure/llm_story_agent.py
@@ -1,0 +1,208 @@
+"""Agent adapter that prompts an LLM to produce narrative events."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from .llm import LLMClient, LLMMessage
+from .multi_agent import Agent, AgentTrigger, AgentTurnResult
+from .story_engine import StoryChoice, StoryEvent
+from .world_state import WorldState
+
+
+def _normalise_limit(value: int | None, *, field_name: str, default: int) -> int:
+    if value is None:
+        return default
+    if not isinstance(value, int):
+        raise TypeError(f"{field_name} must be an int or None, got {type(value)!r}")
+    if value <= 0:
+        raise ValueError(f"{field_name} must be a positive integer")
+    return value
+
+
+def _format_section(title: str, rows: Iterable[str]) -> str:
+    items = [line for line in rows if line]
+    if not items:
+        return f"{title}: (none)"
+    bullet_list = "\n".join(f"- {line}" for line in items)
+    return f"{title}:\n{bullet_list}"
+
+
+@dataclass
+class LLMStoryAgent(Agent):
+    """Agent implementation that uses an :class:`LLMClient` for narration."""
+
+    name: str
+    llm_client: LLMClient
+    system_prompt: str = (
+        "You narrate interactive fiction scenes. Respond with JSON containing "
+        "'narration', and optional 'choices' and 'metadata'."
+    )
+    temperature: float | None = None
+    history_limit: int = 5
+    memory_limit: int = 5
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str):
+            raise TypeError("agent name must be a string")
+        stripped = self.name.strip()
+        if not stripped:
+            raise ValueError("agent name must be non-empty")
+        self.name = stripped
+
+        if not isinstance(self.system_prompt, str):
+            raise TypeError("system_prompt must be a string")
+        system_prompt = self.system_prompt.strip()
+        if not system_prompt:
+            raise ValueError("system_prompt must be a non-empty string")
+        self.system_prompt = system_prompt
+
+        self.history_limit = _normalise_limit(
+            self.history_limit,
+            field_name="history_limit",
+            default=5,
+        )
+        self.memory_limit = _normalise_limit(
+            self.memory_limit,
+            field_name="memory_limit",
+            default=5,
+        )
+
+    def propose_event(
+        self,
+        world_state: WorldState,
+        *,
+        trigger: AgentTrigger,
+    ) -> AgentTurnResult:
+        messages = self._build_messages(world_state, trigger)
+        response = self.llm_client.complete(messages, temperature=self.temperature)
+        event = self._parse_response(response.message.content)
+        metadata = self._merge_metadata(event.metadata, response.metadata)
+        event_with_metadata = StoryEvent(
+            narration=event.narration,
+            choices=event.choices,
+            metadata=metadata,
+        )
+        return AgentTurnResult(event=event_with_metadata)
+
+    def _build_messages(
+        self, world_state: WorldState, trigger: AgentTrigger
+    ) -> Sequence[LLMMessage]:
+        context = self._render_context(world_state, trigger)
+        instructions = (
+            "Return a compact JSON object. Example format: "
+            "{\"narration\": str, \"choices\": [{\"command\": str, \"description\": str}], "
+            "\"metadata\": {str: str}}. Omit keys you do not need."
+        )
+        user_prompt = f"{context}\n\n{instructions}"
+        return [
+            LLMMessage(role="system", content=self.system_prompt),
+            LLMMessage(role="user", content=user_prompt),
+        ]
+
+    def _render_context(
+        self, world_state: WorldState, trigger: AgentTrigger
+    ) -> str:
+        inventory = ", ".join(sorted(world_state.inventory)) or "(empty)"
+        history = world_state.history[-self.history_limit :]
+        actions = world_state.recent_actions(limit=self.memory_limit)
+        observations = world_state.recent_observations(limit=self.memory_limit)
+
+        sections = [
+            f"Trigger kind: {trigger.kind}",
+        ]
+        if trigger.player_input:
+            sections.append(f"Player input: {trigger.player_input}")
+        if trigger.source_event is not None:
+            sections.append("Previous event narration:")
+            sections.append(trigger.source_event.narration)
+            if trigger.source_event.choices:
+                choice_lines = [
+                    f"{choice.command}: {choice.description}"
+                    for choice in trigger.source_event.choices
+                ]
+                sections.append(_format_section("Previous choices", choice_lines))
+
+        sections.extend(
+            [
+                f"Current location: {world_state.location}",
+                f"Inventory: {inventory}",
+                _format_section("Recent history", history),
+                _format_section("Recent player actions", actions),
+                _format_section("Recent observations", observations),
+            ]
+        )
+
+        return "\n".join(sections)
+
+    def _parse_response(self, payload: str) -> StoryEvent:
+        text = payload.strip()
+        if not text:
+            raise ValueError("LLMStoryAgent received an empty response")
+
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("LLMStoryAgent expected JSON content from the LLM") from exc
+
+        if not isinstance(data, Mapping):
+            raise ValueError("LLMStoryAgent response must be a JSON object")
+
+        narration = data.get("narration")
+        if not isinstance(narration, str):
+            raise ValueError("LLMStoryAgent response is missing 'narration'")
+
+        choices_payload = data.get("choices", [])
+        if not isinstance(choices_payload, Sequence) or isinstance(
+            choices_payload, (str, bytes)
+        ):
+            raise ValueError("'choices' must be an array when provided")
+
+        choices: list[StoryChoice] = []
+        for entry in choices_payload:
+            if not isinstance(entry, Mapping):
+                raise ValueError("choice entries must be objects")
+            command = entry.get("command")
+            description = entry.get("description")
+            if not isinstance(command, str) or not isinstance(description, str):
+                raise ValueError("choices must include string command and description")
+            choices.append(StoryChoice(command=command, description=description))
+
+        metadata_payload = data.get("metadata")
+        metadata: Mapping[str, str] | None
+        if metadata_payload is None:
+            metadata = None
+        else:
+            if not isinstance(metadata_payload, Mapping):
+                raise ValueError("'metadata' must be an object when provided")
+            metadata = {str(key): str(value) for key, value in metadata_payload.items()}
+
+        return StoryEvent(
+            narration=narration,
+            choices=tuple(choices),
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _merge_metadata(
+        event_metadata: Mapping[str, str] | None,
+        response_metadata: Mapping[str, str],
+    ) -> Mapping[str, str] | None:
+        if not response_metadata:
+            return event_metadata
+
+        merged: dict[str, str]
+        if event_metadata:
+            merged = dict(event_metadata)
+        else:
+            merged = {}
+
+        for key, value in response_metadata.items():
+            merged.setdefault(f"llm:{key}", value)
+
+        return merged
+
+
+__all__ = ["LLMStoryAgent"]

--- a/tests/test_llm_story_agent.py
+++ b/tests/test_llm_story_agent.py
@@ -1,0 +1,92 @@
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from textadventure import LLMStoryAgent
+from textadventure.multi_agent import AgentTrigger
+from textadventure.story_engine import StoryChoice, StoryEvent
+from textadventure.world_state import WorldState
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from tests.conftest import MockLLMClient
+
+
+def _make_trigger() -> AgentTrigger:
+    return AgentTrigger(
+        kind="story-event",
+        player_input="inspect statue",
+        source_event=StoryEvent(
+            narration="The statue looms over you.",
+            choices=(
+                StoryChoice("touch", "Touch the statue"),
+                StoryChoice("back", "Back away slowly"),
+            ),
+        ),
+    )
+
+
+def test_llm_story_agent_builds_prompt_and_parses_response(
+    mock_llm_client: "MockLLMClient",
+) -> None:
+    world = WorldState()
+    world.move_to("mysterious-cavern")
+    world.add_item("lantern")
+    world.record_event("Entered the cavern")
+    world.record_event("Heard distant whispers")
+    world.remember_action("inspect statue")
+    world.remember_observation("A chill settles in the air")
+
+    response_payload = {
+        "narration": "A hush falls over the cavern as the statue awakens.",
+        "choices": [
+            {"command": "wait", "description": "Wait to see what happens."},
+            {"command": "run", "description": "Run for the exit."},
+        ],
+        "metadata": {"tone": "ominous"},
+    }
+    mock_llm_client.queue_response(
+        json.dumps(response_payload), metadata={"model": "mock-gpt"}
+    )
+
+    agent = LLMStoryAgent(
+        name="oracle",
+        llm_client=mock_llm_client,
+        history_limit=1,
+        memory_limit=1,
+    )
+
+    result = agent.propose_event(world, trigger=_make_trigger())
+
+    assert result.event is not None
+    event = result.event
+    assert event.narration == response_payload["narration"]
+    assert [choice.command for choice in event.choices] == ["wait", "run"]
+    metadata = dict(event.metadata)
+    assert metadata["tone"] == "ominous"
+    assert metadata["llm:model"] == "mock-gpt"
+
+    assert len(mock_llm_client.calls) == 1
+    system_message, user_message = mock_llm_client.calls[0]
+    assert system_message.role == "system"
+    assert "Respond with JSON" in system_message.content
+    assert "Trigger kind: story-event" in user_message.content
+    assert "Player input: inspect statue" in user_message.content
+    assert "touch: Touch the statue" in user_message.content
+    assert "Current location: mysterious-cavern" in user_message.content
+    assert "Inventory: lantern" in user_message.content
+    assert "Recent history:\n- Heard distant whispers" in user_message.content
+    assert "Recent player actions:\n- inspect statue" in user_message.content
+    assert "Recent observations:\n- A chill settles in the air" in user_message.content
+    assert "Entered the cavern" not in user_message.content
+
+
+def test_llm_story_agent_requires_json_response(
+    mock_llm_client: "MockLLMClient",
+) -> None:
+    mock_llm_client.queue_response("Not JSON at all")
+
+    agent = LLMStoryAgent(name="oracle", llm_client=mock_llm_client)
+
+    with pytest.raises(ValueError, match="expected JSON content"):
+        agent.propose_event(WorldState(), trigger=_make_trigger())


### PR DESCRIPTION
## Summary
- add an LLMStoryAgent that builds world-aware prompts and parses JSON responses into StoryEvent objects
- expose the new agent from the package exports and capture LLM response metadata
- cover the agent with focused unit tests and mark the corresponding backlog items complete

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8da2e101c83248e63945f30ca7b04