### PR TITLE
Add configurable memory requests for agent prompts

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -59,7 +59,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [x] Build a structured prompt generator that summarises the world state and trigger context for the LLM.
   - [x] Parse JSON responses from the LLM into `StoryEvent` instances with validation.
   - [x] Cover the agent with unit tests demonstrating prompt construction and error handling.
-- [ ] Extend the memory system so agents can request recent observations/actions as part of their prompts, with configuration for how much history to include.
+- [x] Extend the memory system so agents can request recent observations/actions as part of their prompts, with configuration for how much history to include. *(Added `MemoryRequest` for triggers, debug visibility, and overrides in `LLMStoryAgent` with regression tests.)*
 - [ ] Provide integration tests (or golden transcripts) that exercise a hybrid scripted + LLM-backed coordinator using deterministic fixtures.
 
 ## Priority 7: Observability & Tooling

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -23,7 +23,7 @@ from .persistence import (
     SessionSnapshot,
     SessionStore,
 )
-from .memory import MemoryEntry, MemoryLog
+from .memory import MemoryEntry, MemoryLog, MemoryRequest
 from .tools import KnowledgeBaseTool, Tool, ToolResponse
 from .world_state import WorldState
 
@@ -48,6 +48,7 @@ __all__ = [
     "KnowledgeBaseTool",
     "MemoryEntry",
     "MemoryLog",
+    "MemoryRequest",
     "LLMClient",
     "LLMClientError",
     "LLMMessage",

--- a/src/textadventure/llm_story_agent.py
+++ b/src/textadventure/llm_story_agent.py
@@ -107,8 +107,17 @@ class LLMStoryAgent(Agent):
     ) -> str:
         inventory = ", ".join(sorted(world_state.inventory)) or "(empty)"
         history = world_state.history[-self.history_limit :]
-        actions = world_state.recent_actions(limit=self.memory_limit)
-        observations = world_state.recent_observations(limit=self.memory_limit)
+        memory_request = trigger.memory_request
+        if memory_request is None:
+            action_limit = self.memory_limit
+            observation_limit = self.memory_limit
+        else:
+            action_limit = memory_request.resolve_action_limit(self.memory_limit)
+            observation_limit = memory_request.resolve_observation_limit(
+                self.memory_limit
+            )
+        actions = world_state.recent_actions(limit=action_limit)
+        observations = world_state.recent_observations(limit=observation_limit)
 
         sections = [
             f"Trigger kind: {trigger.kind}",

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,6 +1,8 @@
 """Tests for the lightweight memory utilities."""
 
-from textadventure.memory import MemoryLog
+import pytest
+
+from textadventure.memory import MemoryLog, MemoryRequest
 
 
 def test_remember_normalises_fields() -> None:
@@ -39,3 +41,18 @@ def test_find_by_tag_matches_case_insensitively() -> None:
     matches = log.find_by_tag("Clue")
 
     assert matches == (first,)
+
+
+def test_memory_request_validates_and_resolves_limits() -> None:
+    request = MemoryRequest(action_limit=2, observation_limit=0)
+
+    assert request.resolve_action_limit(5) == 2
+    assert request.resolve_observation_limit(5) == 0
+
+
+def test_memory_request_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError):
+        MemoryRequest(action_limit=-1)
+
+    with pytest.raises(TypeError):
+        MemoryRequest(observation_limit="many")  # type: ignore[arg-type]

--- a/tests/test_multi_agent.py
+++ b/tests/test_multi_agent.py
@@ -14,6 +14,7 @@ from textadventure.multi_agent import (
     QueuedAgentMessage,
     ScriptedStoryAgent,
 )
+from textadventure.memory import MemoryRequest
 from textadventure.scripted_story_engine import ScriptedStoryEngine
 from textadventure.story_engine import StoryChoice, StoryEvent
 from textadventure.world_state import WorldState
@@ -211,6 +212,7 @@ def test_coordinator_debug_snapshot_reports_queued_messages() -> None:
                     AgentTrigger(
                         kind="alert",
                         metadata={"target": "scout", "note": "prepare"},
+                        memory_request=MemoryRequest(action_limit=2),
                     ),
                 ),
             ),
@@ -239,6 +241,7 @@ def test_coordinator_debug_snapshot_reports_queued_messages() -> None:
     assert queued.trigger_kind == "alert"
     assert queued.player_input is None
     assert dict(queued.metadata) == {"note": "prepare", "target": "scout"}
+    assert queued.memory_request == MemoryRequest(action_limit=2)
 
     with pytest.raises(TypeError):
         queued.metadata["target"] = "other"  # type: ignore[index]


### PR DESCRIPTION
## Summary
- add a MemoryRequest helper so triggers can specify how many recent actions and observations to include
- propagate requested limits through agent triggers, coordinator debug snapshots, and the LLM story agent prompt builder
- expand tests to cover memory request validation, snapshot visibility, and LLM prompt overrides while updating the backlog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8e76ad5d88324b25c14d4ddf04feb