### PR TITLE
Add CLI transcript logging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Additional project planning notes live in [`TASKS.md`](TASKS.md).
    ```bash
    python src/main.py
    ```
-   Use `python src/main.py --help` to discover save/load options.
+   Use `python src/main.py --help` to discover save/load options. Pass
+   `--log-file transcript.txt` to record a debugging transcript that captures
+   narration, player input, and any agent metadata emitted during the session.
 
 ## Customising the Demo Adventure
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -63,7 +63,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
 - [ ] Provide integration tests (or golden transcripts) that exercise a hybrid scripted + LLM-backed coordinator using deterministic fixtures.
 
 ## Priority 7: Observability & Tooling
-- [ ] Add transcript logging options to the CLI (e.g., `--log-file`) that capture narration, player input, and agent metadata for debugging sessions.
+- [x] Add transcript logging options to the CLI (e.g., `--log-file`) that capture narration, player input, and agent metadata for debugging sessions.
+  - [x] Outline transcript logging format and captured fields.
+  - [x] Implement the CLI `--log-file` flag with a structured transcript writer.
+  - [x] Add regression tests and documentation covering the logging workflow.
 - [x] Introduce a debug command (such as `status`) that prints the active location, inventory summary, queued agent messages, and pending saves.
   - [x] Provide a coordinator debug snapshot with visibility into queued messages.
   - [x] Surface the world/persistence details through a CLI `status` command and cover it with tests.


### PR DESCRIPTION
## Summary
- add a transcript logger to the CLI loop to capture narration, metadata, choices, and player commands
- expose a `--log-file` flag in the entry point and update the README plus backlog guidance
- cover the logging flow with a dedicated unit test

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8eab07118832496a2060c8a0413cf