### PR TITLE
Allow CLI to attach LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,27 @@ TASKS.md                   # Planning notes and backlog ideas
    ```
    Run `python src/main.py --help` to discover options for enabling persistence
    (`--session-dir`, `--session-id`, `--no-persistence`) and transcript logging
-   (`--log-file`).
+   (`--log-file`). The CLI can also attach an LLM-backed secondary narrator via
+   `--llm-provider`, forwarding additional key/value pairs to the selected
+   provider with repeated `--llm-option` flags (for example,
+   `--llm-provider openai --llm-option api_key=...`).
+
+### Adding an LLM Co-narrator
+
+Use the provider registry flags to experiment with LLM-driven agents alongside
+the scripted narrator:
+
+```bash
+python src/main.py \
+  --llm-provider my_package.llm:build_client \
+  --llm-option api_key="sk-demo" \
+  --llm-option model="fiction-gpt"
+```
+
+The registry resolves registered provider names or dynamic import paths of the
+form `module:factory`. Each `--llm-option` supplies a `key=value` pair that is
+parsed as JSON when possible (e.g., numbers, booleans) before being forwarded to
+the provider factory.
 
 ## Customising the Demo Adventure
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -90,5 +90,8 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [x] Support instantiating providers from configuration mappings (e.g., parsed config files).
   - [x] Support instantiating providers from CLI-style option strings for manual selection.
   - [x] Cover the registry behaviour with automated tests, including dynamic import and error handling.
-  - [ ] Update the CLI and coordinator wiring so adventures can select LLM providers at runtime.
+  - [x] Update the CLI and coordinator wiring so adventures can select LLM providers at runtime.
+    - [x] Add CLI flags for selecting an LLM provider and passing option key/value pairs.
+    - [x] Instantiate LLM-backed agents via the provider registry when configured and integrate them with the coordinator.
+    - [x] Document the workflow and add regression tests covering provider selection.
   - [ ] Ensure registry lookups and adapter instantiation are covered by tests, including misconfiguration handling.

--- a/docs/multi_agent_orchestration.md
+++ b/docs/multi_agent_orchestration.md
@@ -21,7 +21,10 @@ narrative.
 This setup assumes a single authoritative story engine that owns both narrative
 logic and NPC behaviour. To support multi-agent scenarios we need a layer that
 can orchestrate multiple story contributors, arbitrate their outputs, and keep
-the world state consistent.
+the world state consistent. The CLI demo exposes this orchestration path by
+allowing an LLM-backed secondary narrator to be attached at runtime with the
+`--llm-provider` flag, keeping experimentation in parity with the scripted
+primary agent.
 
 ## Proposed Components
 1. **Agent Interface**

--- a/tests/test_main_entrypoint.py
+++ b/tests/test_main_entrypoint.py
@@ -1,0 +1,81 @@
+"""Tests covering the CLI entry point and provider selection flags."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from textwrap import dedent
+
+import pytest
+
+from main import main
+
+
+def test_main_supports_llm_provider_selection(tmp_path, monkeypatch, capsys) -> None:
+    """Providing an LLM provider should wire it into the coordinator."""
+
+    module_path = tmp_path / "dummy_llm_provider.py"
+    module_path.write_text(
+        dedent(
+            """
+            import json
+
+            from textadventure.llm import LLMClient, LLMMessage, LLMResponse
+
+
+            class DummyLLMClient(LLMClient):
+                def __init__(self, narration: str = "oracle", note: str = "") -> None:
+                    self.narration = narration
+                    self.note = note
+
+                def complete(self, messages, *, temperature=None):
+                    payload = {"narration": self.narration}
+                    if self.note:
+                        payload["metadata"] = {"note": self.note}
+                    response = json.dumps(payload)
+                    return LLMResponse(
+                        LLMMessage(role="assistant", content=response),
+                        metadata={"provider": "dummy"},
+                    )
+
+
+            def build_client(**options):
+                return DummyLLMClient(**options)
+            """
+        )
+    )
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    inputs = iter(["quit"])
+    monkeypatch.setattr(builtins, "input", lambda prompt="": next(inputs))
+
+    try:
+        main(
+            [
+                "--llm-provider",
+                "dummy_llm_provider:build_client",
+                "--llm-option",
+                "narration=LLM-guidance",
+                "--llm-option",
+                "note=clue",
+                "--no-persistence",
+            ]
+        )
+    finally:
+        sys.modules.pop("dummy_llm_provider", None)
+
+    output = capsys.readouterr().out
+    assert "LLM-guidance" in output
+    assert "Thanks for playing!" in output
+
+
+def test_main_rejects_options_without_provider(monkeypatch, capsys) -> None:
+    """Supplying provider options without a provider should exit early."""
+
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--llm-option", "note=clue", "--no-persistence"])
+
+    assert excinfo.value.code == 2
+    error_output = capsys.readouterr().out
+    assert "--llm-option was provided" in error_output


### PR DESCRIPTION
## Summary
- add CLI flags that resolve LLM providers through the registry and attach them as secondary agents in the coordinator
- cover the new CLI options with entrypoint tests and mark the backlog item complete
- document the provider workflow in the README and orchestration design notes

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d90a8379d48324b8c16fc36fc4e298