### PR TITLE
Add recorded transcript integration tests for LLM story agent

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -85,7 +85,9 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [x] Implement a configurable retry policy with exponential backoff and optional jitter.
   - [x] Add a shared fixed-interval rate limiter that adapters can reuse to throttle requests.
   - [x] Cover the new helpers with deterministic unit tests.
-  - [ ] Add integration tests using recorded responses or fixtures to validate prompt/response translation and error handling.
+- [x] Add integration tests using recorded responses or fixtures to validate prompt/response translation and error handling.
+  - [x] Replay recorded transcript fixtures to assert prompts, choices, and metadata merge correctly.
+  - [x] Cover misconfigured fixture payloads to verify descriptive error handling from LLMStoryAgent.
 - [ ] Implement adapters for local runtimes (e.g., Hugging Face Text Generation Inference, llama.cpp servers) so self-hosted models can plug into the same flow.
   - [ ] Document setup instructions and configuration flags required to target each local runtime.
   - [ ] Add smoke tests or mocks verifying adapters handle streaming, chunked responses, and offline failure scenarios.

--- a/tests/data/llm_recorded_transcripts.json
+++ b/tests/data/llm_recorded_transcripts.json
@@ -1,0 +1,110 @@
+{
+  "world": {
+    "location": "ancient-library",
+    "inventory": [
+      "torch",
+      "map"
+    ],
+    "history": [
+      "Entered the ancient library",
+      "A layer of dust muffles every sound"
+    ],
+    "actions": [
+      "look around"
+    ],
+    "observations": [
+      "Cobwebs sway gently between the stacks"
+    ]
+  },
+  "turns": [
+    {
+      "description": "Initial examination of the relic",
+      "player_input": "examine relic",
+      "expected_prompt_snippets": [
+        "Trigger kind: story-event",
+        "Player input: examine relic",
+        "Current location: ancient-library",
+        "Inventory: map, torch",
+        "Recent history:\n- Entered the ancient library\n- A layer of dust muffles every sound",
+        "Recent player actions:\n- look around",
+        "Recent observations:\n- Cobwebs sway gently between the stacks"
+      ],
+      "response_payload": {
+        "narration": "The relic hums softly, casting dancing motes of light.",
+        "choices": [
+          {
+            "command": "study",
+            "description": "Study the glowing runes more carefully."
+          },
+          {
+            "command": "pocket",
+            "description": "Pocket the relic for later."
+          }
+        ],
+        "metadata": {
+          "tone": "curious"
+        }
+      },
+      "response_metadata": {
+        "model": "fixture-gpt",
+        "request_id": "turn-1"
+      },
+      "expected_choices": [
+        "study",
+        "pocket"
+      ],
+      "expected_metadata": {
+        "tone": "curious",
+        "llm:model": "fixture-gpt",
+        "llm:request_id": "turn-1"
+      }
+    },
+    {
+      "description": "Following up on the rune discovery",
+      "player_input": "study",
+      "expected_prompt_snippets": [
+        "Player input: study",
+        "Previous event narration:",
+        "The relic hums softly, casting dancing motes of light.",
+        "Previous choices:\n- study: Study the glowing runes more carefully."
+      ],
+      "response_payload": {
+        "narration": "As you trace the runes, they rearrange into a shimmering map.",
+        "choices": [
+          {
+            "command": "follow",
+            "description": "Follow the path revealed by the shimmering map."
+          }
+        ]
+      },
+      "response_metadata": {
+        "model": "fixture-gpt",
+        "request_id": "turn-2"
+      },
+      "expected_choices": [
+        "follow"
+      ],
+      "expected_metadata": {
+        "llm:model": "fixture-gpt",
+        "llm:request_id": "turn-2"
+      }
+    }
+  ],
+  "invalid_payloads": [
+    {
+      "description": "non-object payload",
+      "payload": "\"nonsense\"",
+      "error_match": "response must be a JSON object"
+    },
+    {
+      "description": "missing narration",
+      "payload": "{\"choices\": []}",
+      "error_match": "missing 'narration'"
+    },
+    {
+      "description": "choices wrong type",
+      "payload": "{\"narration\": \"ok\", \"choices\": \"nope\"}",
+      "error_match": "'choices' must be an array"
+    }
+  ]
+}

--- a/tests/test_llm_recorded_transcripts.py
+++ b/tests/test_llm_recorded_transcripts.py
@@ -1,0 +1,108 @@
+"""Integration-style tests replaying recorded LLM transcripts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List
+
+import pytest
+
+from textadventure import LLMStoryAgent
+from textadventure.multi_agent import AgentTrigger
+from textadventure.story_engine import StoryEvent
+from textadventure.world_state import WorldState
+
+if TYPE_CHECKING:  # pragma: no cover - typing helper
+    from tests.conftest import MockLLMClient
+
+
+_FIXTURE_PATH = (
+    Path(__file__).with_name("data").joinpath("llm_recorded_transcripts.json")
+)
+_RECORDED_FIXTURES: Dict[str, Any] = json.loads(_FIXTURE_PATH.read_text())
+
+
+def _build_world(state: Dict[str, Any]) -> WorldState:
+    world = WorldState()
+    world.move_to(state["location"], record_event=False)
+    for item in state.get("inventory", []):
+        world.add_item(item, record_event=False)
+    world.extend_history(state.get("history", []))
+    for action in state.get("actions", []):
+        world.remember_action(action)
+    for observation in state.get("observations", []):
+        world.remember_observation(observation)
+    return world
+
+
+def _queue_responses(client: "MockLLMClient", turns: Iterable[Dict[str, Any]]) -> None:
+    for turn in turns:
+        payload = json.dumps(turn["response_payload"])
+        metadata = turn.get("response_metadata", {})
+        client.queue_response(payload, metadata=metadata)
+
+
+def test_llm_story_agent_replays_recorded_transcript(
+    mock_llm_client: "MockLLMClient",
+) -> None:
+    transcript = _RECORDED_FIXTURES["turns"]
+    _queue_responses(mock_llm_client, transcript)
+
+    world = _build_world(_RECORDED_FIXTURES["world"])
+    agent = LLMStoryAgent(
+        name="oracle",
+        llm_client=mock_llm_client,
+        history_limit=5,
+        memory_limit=5,
+    )
+
+    previous_event: StoryEvent | None = None
+
+    for index, turn in enumerate(transcript):
+        trigger = AgentTrigger(
+            kind="story-event",
+            player_input=turn.get("player_input"),
+            source_event=previous_event,
+        )
+
+        result = agent.propose_event(world, trigger=trigger)
+        assert result.event is not None
+        event = result.event
+
+        assert event.narration == turn["response_payload"]["narration"]
+        assert [choice.command for choice in event.choices] == turn["expected_choices"]
+
+        metadata = dict(event.metadata or {})
+        assert metadata == turn["expected_metadata"]
+
+        system_message, user_message = mock_llm_client.calls[index]
+        assert system_message.role == "system"
+        for snippet in turn["expected_prompt_snippets"]:
+            assert snippet in user_message.content
+
+        if turn.get("player_input"):
+            world.remember_action(turn["player_input"])
+        world.remember_observation(event.narration)
+        previous_event = event
+
+
+def _invalid_payloads() -> List[Dict[str, str]]:
+    return list(_RECORDED_FIXTURES.get("invalid_payloads", []))
+
+
+@pytest.mark.parametrize(
+    "payload_record",
+    _invalid_payloads(),
+    ids=lambda record: record.get("description", "invalid"),
+)
+def test_llm_story_agent_handles_recorded_invalid_payloads(
+    payload_record: Dict[str, str], mock_llm_client: "MockLLMClient"
+) -> None:
+    mock_llm_client.queue_response(payload_record["payload"])
+
+    agent = LLMStoryAgent(name="oracle", llm_client=mock_llm_client)
+    trigger = AgentTrigger(kind="story-event")
+
+    with pytest.raises(ValueError, match=payload_record["error_match"]):
+        agent.propose_event(world_state=WorldState(), trigger=trigger)


### PR DESCRIPTION
## Summary
- add integration-style tests that replay recorded LLM transcripts to assert prompt construction, choice translation, and metadata merging
- introduce a reusable JSON fixture for the recorded responses, including negative payload scenarios for error handling
- update the backlog to reflect the new coverage work

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d910cee194832485afd4a9d695362b