### PR TITLE
Add CLI support for loading LLM provider configs from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ TASKS.md                   # Planning notes and backlog ideas
    (`--log-file`). The CLI can also attach an LLM-backed secondary narrator via
    `--llm-provider`, forwarding additional key/value pairs to the selected
    provider with repeated `--llm-option` flags (for example,
-   `--llm-provider openai --llm-option api_key=...`).
+   `--llm-provider openai --llm-option api_key=...`). Alternatively pass
+   `--llm-config path/to/config.json` to load the provider identifier and
+   options from a JSON file.
 
 ### Adding an LLM Co-narrator
 
@@ -88,6 +90,21 @@ The registry resolves registered provider names or dynamic import paths of the
 form `module:factory`. Each `--llm-option` supplies a `key=value` pair that is
 parsed as JSON when possible (e.g., numbers, booleans) before being forwarded to
 the provider factory.
+
+JSON configuration files expose the same fields in a reusable format:
+
+```json
+{
+  "provider": "openai",
+  "options": {
+    "api_key": "sk-demo",
+    "model": "gpt-4o-mini"
+  }
+}
+```
+
+Launch the CLI with `--llm-config config/openai.json` to load the provider
+without specifying multiple command-line flags.
 
 ### Built-in provider adapters
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -95,7 +95,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
 - [x] Implement adapters for local runtimes (e.g., Hugging Face Text Generation Inference, llama.cpp servers) so self-hosted models can plug into the same flow.
   - [x] Document setup instructions and configuration flags required to target each local runtime.
   - [x] Add smoke tests or mocks verifying adapters handle streaming, chunked responses, and offline failure scenarios.
-- [ ] Create a provider registry that loads adapters dynamically based on configuration files or CLI options.
+- [x] Create a provider registry that loads adapters dynamically based on configuration files or CLI options.
   - [x] Define an `LLMProviderRegistry` that handles registering and resolving provider factories.
   - [x] Support instantiating providers from configuration mappings (e.g., parsed config files).
   - [x] Support instantiating providers from CLI-style option strings for manual selection.
@@ -105,3 +105,4 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
     - [x] Instantiate LLM-backed agents via the provider registry when configured and integrate them with the coordinator.
     - [x] Document the workflow and add regression tests covering provider selection.
   - [x] Ensure registry lookups and adapter instantiation are covered by tests, including misconfiguration handling. *(Added coverage for dynamic import errors, invalid identifiers, and duplicate CLI options to assert descriptive failures.)*
+  - [x] Support loading provider configuration from JSON files and exposing a matching CLI flag. *(Added `LLMProviderRegistry.create_from_config_file`, CLI wiring, tests, and documentation.)*


### PR DESCRIPTION
## Summary
- add a JSON config loader to `LLMProviderRegistry` and surface a `--llm-config` CLI option
- document the new workflow and expand the provider registry tests to cover config files
- update the backlog to reflect the completed provider registry milestone

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d91dac6c488324a5053f05432eec9d