### PR TITLE
Update docs for current agent framework layout

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -9,36 +9,44 @@ coordination, tool use, LLM-backed storytellers, and session persistence.
 
 ## Key Components
 
-The `src/` directory contains the runtime code published as the
-`textadventure` package:
+The runtime code lives in `src/` and is published as the `textadventure`
+package. Highlights include:
 
-- **`main.py`** – CLI entry point that wires the world state, story engine,
-  multi-agent coordinator, transcript logging, and optional session
-  persistence together.
-- **`textadventure/world_state.py`** – data model representing locations,
-  actors, inventory, observations, and remembered player actions.
-- **`textadventure/memory.py`** – rolling log of agent memories and utilities
-  for replaying remembered observations/actions.
-- **`textadventure/story_engine.py`** – protocol defining how story events are
-  generated and formatted.
-- **`textadventure/scripted_story_engine.py`** – deterministic story engine
-  used by the demo adventure, including helpers for loading JSON scenes.
+- **`src/main.py`** – CLI entry point that wires the world state, story engine,
+  multi-agent coordinator, transcript logging, and optional persistence. It also
+  exposes flags for registering LLM co-narrators through the provider registry.
+- **`textadventure/world_state.py`** – data model describing locations, actors,
+  inventory, observations, and remembered player actions.
+- **`textadventure/memory.py`** – rolling log of agent memories plus utilities
+  for replaying observations/actions.
+- **`textadventure/story_engine.py`** – protocol defining how narrative beats
+  are generated and formatted.
+- **`textadventure/scripted_story_engine.py`** – deterministic story engine used
+  by the demo adventure, including helpers for loading JSON scenes from disk or
+  in-memory mappings.
 - **`textadventure/multi_agent.py`** – lightweight coordinator that lets
   multiple agents take turns responding to player input while exposing debug
   metadata.
 - **`textadventure/llm_story_agent.py`** – adapter that routes coordinator
   prompts through an LLM-backed decision-maker.
 - **`textadventure/llm.py`** – abstractions for integrating LLM providers when
-  experimenting with generative story engines.
-- **`textadventure/tools.py`** – base interfaces for tool-calling agents plus a
+  experimenting with generative story engines (shared message/response models
+  plus streaming helpers).
+- **`textadventure/llm_provider_registry.py`** – command-line friendly registry
+  that resolves provider identifiers, parses `--llm-option` flags, and builds
+  configured clients.
+- **`textadventure/llm_providers/`** – adapters for specific hosted and local
+  LLM providers (OpenAI, Anthropic, Cohere, Hugging Face Text Generation
+  Inference, and llama.cpp).
+- **`textadventure/tools.py`** – base interfaces for tool-calling agents and a
   simple knowledge-base lookup tool.
-- **`textadventure/persistence.py`** – session snapshot helpers and
-  filesystem-backed storage used by the CLI save/load commands.
+- **`textadventure/persistence.py`** – session snapshot helpers and storage
+  backends used by the CLI save/load commands.
 - **`textadventure/data/scripted_scenes.json`** – bundled demo adventure
   definition consumed by the scripted engine.
 
-Design notes and experiments live under `docs/`, and automated tests cover the
-package in `tests/`.
+Design notes and experiment write-ups live in `docs/`, and the automated test
+suite resides under `tests/`.
 
 ## Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ integration.
 ## Highlights
 
 - **Interactive CLI demo** – `src/main.py` wires the story engine, world state,
-  persistence, and optional transcript logging into a small playable loop.
+  persistence, optional transcript logging, and the LLM provider registry into a
+  small playable loop.
 - **Rich world modelling** – `WorldState` tracks locations, actors, inventory,
   remembered observations, and player actions.
 - **Story engines** – the `StoryEngine` protocol defines how narrative beats
   are proposed; `ScriptedStoryEngine` provides a deterministic storyline that
   is easy to extend or replace.
 - **Multi-agent orchestration** – `MultiAgentCoordinator` coordinates one or
-  more `Agent` implementations. The included `ScriptedStoryAgent` narrates the
+  more `Agent` implementations. The bundled `ScriptedStoryAgent` narrates the
   demo adventure, while `LLMStoryAgent` shows how to route decisions through an
   LLM-backed actor.
 - **Data-driven content** – the sample adventure reads its locations from
@@ -24,6 +25,9 @@ integration.
   touching Python code.
 - **Tooling hooks** – `Tool` and `KnowledgeBaseTool` illustrate how agents can
   extend their capabilities beyond pure text generation.
+- **Provider registry** – `LLMProviderRegistry` and the adapters in
+  `textadventure/llm_providers/` make it easy to register OpenAI, Anthropic,
+  Cohere, Hugging Face Text Generation Inference, or llama.cpp co-narrators.
 - **Session persistence** – `FileSessionStore` enables save/load checkpoints
   directly from the CLI demo.
 
@@ -35,15 +39,16 @@ src/
   textadventure/
     __init__.py            # Public package surface
     llm.py                 # LLM client abstractions + helpers
-    llm_providers/         # Adapters for hosted and local LLM providers
-    llm_story_agent.py     # Agent bridge between the coordinator and an LLM
-    memory.py              # Memory log utilities
-    multi_agent.py         # Agent coordination primitives
-    persistence.py         # Session snapshot + storage helpers
-    scripted_story_engine.py
-    story_engine.py        # Story event interfaces
-    tools.py               # Tool interface & knowledge base example
-    world_state.py         # Core world data model
+    llm_provider_registry.py # CLI-friendly registry for configuring providers
+    llm_providers/           # Adapters for hosted and local LLM providers
+    llm_story_agent.py       # Agent bridge between the coordinator and an LLM
+    memory.py                # Memory log utilities
+    multi_agent.py           # Agent coordination primitives
+    persistence.py           # Session snapshot + storage helpers
+    scripted_story_engine.py # Deterministic engine + JSON loaders
+    story_engine.py          # Story event interfaces
+    tools.py                 # Tool interface & knowledge base example
+    world_state.py           # Core world data model
     data/
       scripted_scenes.json # Bundled demo adventure definition
 


### PR DESCRIPTION
## Summary
- refresh Agents guide with up-to-date module descriptions, including the provider registry and hosted/local adapters
- update the README highlights and repository layout to match the current package structure and CLI capabilities

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d91f9126f4832493c776a9f4353090