### PR TITLE
Add coverage for gated scripted scene transitions

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -126,6 +126,6 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [x] Review lore flavour interactions to highlight journal and memory hooks.
   - [ ] Mark the original checklist item complete once all subtasks pass review.
 - [ ] Update scripted-engine tests and fixtures to cover the expanded scene graph and any new command patterns.
-  - [ ] Add regression coverage validating transition targets, required items, and failure messages for gated actions.
+  - [x] Add regression coverage validating transition targets, required items, and failure messages for gated actions. *(Added targeted tests for the ranger signal gate, flooded archives study requirement, and related success flows.)*
   - [ ] Refresh golden transcripts (if any) so the CLI demo walkthrough exercises the broader storyline.
 - [ ] Document the enhanced demo in `docs/data_driven_scenes.md`, including a high-level map, quest summaries, and authoring tips for further expansion.

--- a/tests/test_scripted_story_engine.py
+++ b/tests/test_scripted_story_engine.py
@@ -164,6 +164,33 @@ def test_locked_hall_requires_key() -> None:
     assert "fallen pillars" in success_event.narration.lower()
 
 
+def test_ranger_training_grants_signal_lesson() -> None:
+    world = WorldState(location="ranger-lookout")
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world, player_input="train")
+
+    assert "signal" in event.narration.lower()
+    assert "signal lesson" in world.inventory
+
+
+def test_crypt_requires_signal_lesson() -> None:
+    world = WorldState(location="collapsed-hall")
+    engine = ScriptedStoryEngine()
+
+    failure_event = engine.propose_event(world, player_input="crypt")
+
+    assert "ranger's signal" in failure_event.narration.lower()
+    assert world.location == "collapsed-hall"
+
+    world.add_item("signal lesson")
+
+    success_event = engine.propose_event(world, player_input="crypt")
+
+    assert world.location == "sealed-crypt"
+    assert "practiced signal" in success_event.narration.lower()
+
+
 def test_crafting_consumes_components() -> None:
     world = WorldState(location="astral-workshop")
     engine = ScriptedStoryEngine()
@@ -194,3 +221,19 @@ def test_observatory_activation_requires_items() -> None:
     success_event = engine.propose_event(world, player_input="activate")
 
     assert "pathways of light" in success_event.narration.lower()
+
+
+def test_archives_study_requires_map() -> None:
+    world = WorldState(location="flooded-archives")
+    engine = ScriptedStoryEngine()
+
+    failure_event = engine.propose_event(world, player_input="study")
+
+    assert "weathered map" in failure_event.narration.lower()
+    assert world.location == "flooded-archives"
+
+    world.add_item("weathered map")
+
+    success_event = engine.propose_event(world, player_input="study")
+
+    assert "hidden annotations" in success_event.narration.lower()


### PR DESCRIPTION
## Summary
- add regression tests covering the ranger signal lesson, crypt access, and flooded archive study gating
- document the completed gating coverage work in TASKS.md

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9c638bf148324b9970df468ed95a5