### PR TITLE
Add regression tests for journal and inventory summaries

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -130,7 +130,8 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [x] Define the Aether Spire ascent and finale scaffolding.
   - [x] Review lore flavour interactions to highlight journal and memory hooks.
   - [ ] Mark the original checklist item complete once all subtasks pass review.
-- [ ] Update scripted-engine tests and fixtures to cover the expanded scene graph and any new command patterns.
+- [x] Update scripted-engine tests and fixtures to cover the expanded scene graph and any new command patterns.
   - [x] Add regression coverage validating transition targets, required items, and failure messages for gated actions. *(Added targeted tests for the ranger signal gate, flooded archives study requirement, and related success flows.)*
+  - [x] Add coverage for the new `journal` and `inventory` command summaries. *(Added tests asserting history truncation and alphabetised inventory listings.)*
 - [x] Refresh golden transcripts (if any) so the CLI demo walkthrough exercises the broader storyline. *(Captured an updated CLI walkthrough transcript and regression test to cover the expanded regions.)*
 - [x] Document the enhanced demo in `docs/data_driven_scenes.md`, including a high-level map, quest summaries, and authoring tips for further expansion. *(Added an "Expanded Demo Reference" section summarising regions, quest flow, and future authoring guidance.)*

--- a/tests/test_scripted_story_engine.py
+++ b/tests/test_scripted_story_engine.py
@@ -73,6 +73,56 @@ def test_recall_command_reports_recent_actions() -> None:
     assert "explore the gate" in event.narration
 
 
+def test_journal_command_reports_recent_history() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    for index in range(6):
+        world.record_event(f"Logged event {index}")
+
+    event = engine.propose_event(world, player_input="journal")
+
+    assert "flip through your journal" in event.narration.lower()
+    assert "- Logged event 1" in event.narration
+    assert "- Logged event 5" in event.narration
+    assert "- Logged event 0" not in event.narration
+
+
+def test_journal_command_handles_empty_history() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world, player_input="journal")
+
+    assert "journal is blank" in event.narration.lower()
+
+
+def test_inventory_command_summarises_sorted_items() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    world.add_item("weathered map")
+    world.add_item("sunstone lens")
+
+    event = engine.propose_event(world, player_input="inventory")
+
+    assert "your pack currently holds" in event.narration.lower()
+    assert "sunstone lens" in event.narration
+    assert "weathered map" in event.narration
+    assert event.narration.index("sunstone lens") < event.narration.index(
+        "weathered map"
+    )
+
+
+def test_inventory_command_handles_empty_pack() -> None:
+    world = WorldState()
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world, player_input="inventory")
+
+    assert "find nothing" in event.narration.lower()
+
+
 def test_tool_command_returns_lore_entry() -> None:
     world = WorldState(location="old-gate")
     engine = ScriptedStoryEngine()


### PR DESCRIPTION
## Summary
- add scripted story engine tests covering the journal history summary and empty state
- verify the inventory command reports alphabetised items alongside the empty-pack narration
- document the completed test coverage work in `TASKS.md`

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9ccf374908324ac851e48083747e7