### PR TITLE
Fix collapsed hall look transition JSON formatting

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -129,6 +129,8 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [x] Author narrative beats for the Sunken Bastion hub scenes.
   - [x] Define the Aether Spire ascent and finale scaffolding.
   - [x] Review lore flavour interactions to highlight journal and memory hooks.
+  - [x] Validate the expanded scene data for structural errors and fix any inconsistencies discovered.
+    - [x] Correct the malformed `look` transition formatting in the `collapsed-hall` scene.
   - [ ] Mark the original checklist item complete once all subtasks pass review.
 - [x] Update scripted-engine tests and fixtures to cover the expanded scene graph and any new command patterns.
   - [x] Add regression coverage validating transition targets, required items, and failure messages for gated actions. *(Added targeted tests for the ranger signal gate, flooded archives study requirement, and related success flows.)*

--- a/src/textadventure/data/scripted_scenes.json
+++ b/src/textadventure/data/scripted_scenes.json
@@ -193,8 +193,8 @@
     ],
     "transitions": {
       "look": {
-        "narration": "Echoes linger in the vaulted ceiling, amplifying even quiet notes."}
-      ,
+        "narration": "Echoes linger in the vaulted ceiling, amplifying even quiet notes."
+      },
       "excavate": {
         "narration": "Beneath the rubble you uncover a shard that vibrates when held near the sigils.",
         "item": "echo shard"


### PR DESCRIPTION
## Summary
- fix the malformed `look` transition entry in the collapsed hall scene so the scripted data remains valid JSON
- update the backlog to capture and complete the data validation follow-up task

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9ceec38988324a015bd283060fec4