### PR TITLE
Fix LlamaCppClient CLI option override bug

### DIFF
--- a/src/textadventure/llm_providers/local.py
+++ b/src/textadventure/llm_providers/local.py
@@ -214,11 +214,14 @@ class LlamaCppClient(LLMClient):
             "temperature": 0.7,
             "top_p": 0.9,
             "repeat_penalty": 1.1,
-            "max_tokens": 150,  # Reasonable limit for narration
+            "max_tokens": 500,  # More generous limit to avoid JSON truncation
         }
 
         if default_options:
             optimized_defaults.update(default_options)
+
+        # CLI options should override defaults
+        optimized_defaults.update(client_options)
 
         self._default_options = optimized_defaults
 


### PR DESCRIPTION
- CLI options (--llm-option) were being ignored instead of overriding defaults
- Added client_options update to ensure CLI parameters take precedence
- Increased default max_tokens from 150 to 500 to prevent JSON truncation
- Resolves JSON parsing errors in llama.cpp provider integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)