### PR TITLE
Add sky sanctum finale to scripted adventure

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -111,7 +111,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
 - [x] Plan an expanded narrative arc that showcases branching paths, inventory gating, and optional side objectives. *(Documented in the "Planned Narrative Expansion" section of `docs/data_driven_scenes.md`.)*
   - [x] Sketch a location graph covering at least three distinct regions plus connecting transitional scenes.
   - [x] Identify key items, puzzle locks, and narrative beats that can be expressed purely through the JSON schema.
-- [ ] Extend `src/textadventure/data/scripted_scenes.json` with the new regions, ensuring consistent descriptions, commands, and transitions.
+  - [x] Extend `src/textadventure/data/scripted_scenes.json` with the new regions, ensuring consistent descriptions, commands, and transitions. *(Introduced a post-observatory resonant bridge and sky sanctum finale to round out the storyline.)*
   - [x] Add region hubs for the Sunken Bastion and Aether Spire that connect the planned scene graph.
   - [x] Populate optional detours (`scavenger-camp`, `ranger-lookout`, side rooms) with unique interactions and returns.
   - [x] Gate at least one transition on collected items to set up later objectives.

--- a/docs/data_driven_scenes.md
+++ b/docs/data_driven_scenes.md
@@ -183,7 +183,7 @@ Forest Approach
                  └─> ranger-lookout                └─> echoing-stair ──> aether-spire-base
                                                                        ├─> astral-workshop
                                                                        ├─> chronicle-chamber
-                                                                       └─> celestial-observatory
+                                                                       └─> celestial-observatory ──> resonant-bridge ──> sky-sanctum
 ```
 
 - **Forest Approach** introduces navigation, the lore `guide`, and optional
@@ -214,9 +214,12 @@ Forest Approach
    `chronicle-chamber` for optional exposition when carrying the **weathered
    map**.
 5. **Observatory Finale** – Combine the **sunstone lens** and **resonant chime**
-   at the `celestial-observatory` to trigger the closing narration. Players who
-   skipped optional objectives receive tailored failure narration nudging them
-   toward outstanding tasks.
+   at the `celestial-observatory` to open the resonant bridge toward the
+   sanctum. Players who skipped optional objectives receive tailored failure
+   narration nudging them toward outstanding tasks.
+6. **Sanctum Resolution** – Cross the `resonant-bridge` with the **ancient
+   sigil** and stabilise the `sky-sanctum` using the crafted chime to conclude
+   the storyline and record the final history beat.
 
 ### Authoring Tips for Further Expansion
 

--- a/src/textadventure/data/scripted_scenes.json
+++ b/src/textadventure/data/scripted_scenes.json
@@ -425,8 +425,10 @@
       },
       "activate": {
         "narration": "You set the sunstone lens within the dais and ring the resonant chime. The pylons answer, harmonising with the night sky as pathways of light unfurl before you.",
+        "target": "resonant-bridge",
         "requires": ["sunstone lens", "resonant chime"],
-        "failure_narration": "The machinery sputters—the observatory clearly expects both the sunstone lens and resonant chime."
+        "failure_narration": "The machinery sputters—the observatory clearly expects both the sunstone lens and resonant chime.",
+        "records": ["Opened the resonant bridge"]
       },
       "reflect": {
         "narration": "Memories of the journey ripple through the dome, painting constellations that echo your choices."
@@ -434,6 +436,69 @@
       "return": {
         "narration": "You descend the lattice back toward the spire base.",
         "target": "aether-spire-base"
+      }
+    }
+  },
+  "resonant-bridge": {
+    "description": "A ribbon of light arches from the observatory into the night, each step echoing with soft chimes that react to the sigil at your side.",
+    "choices": [
+      {"command": "look", "description": "Study the flowing constellations."},
+      {"command": "advance", "description": "Follow the luminous path toward the distant sanctum."},
+      {"command": "linger", "description": "Pause to absorb the surrounding harmony."},
+      {"command": "return", "description": "Ease back toward the observatory dais."},
+      {"command": "inventory", "description": "Check your belongings."},
+      {"command": "journal", "description": "Look over your recorded memories."},
+      {"command": "recall", "description": "Reflect on your recent decisions."},
+      {
+        "command": "guide",
+        "description": "Consult the field guide for lore (e.g. 'guide bridge')."
+      }
+    ],
+    "transitions": {
+      "look": {
+        "narration": "Stars stream past like notes on a staff, adjusting their rhythm as you breathe."
+      },
+      "advance": {
+        "narration": "The sigil glows in resonance, solidifying the path ahead as it carries you toward the sanctum suspended among the clouds.",
+        "target": "sky-sanctum",
+        "requires": ["ancient sigil"],
+        "failure_narration": "Without the ancient sigil, the bridge frays into starlight and refuses to bear your weight."
+      },
+      "linger": {
+        "narration": "You listen for the subtle harmonies woven through the bridge, letting the cadence settle in your bones.",
+        "records": ["Lingering on the resonant bridge"]
+      },
+      "return": {
+        "narration": "You retreat along the glowing span, arriving once more at the observatory's dais.",
+        "target": "celestial-observatory"
+      }
+    }
+  },
+  "sky-sanctum": {
+    "description": "An airy chamber of starlit currents drifts above the spire. Crystalline pillars pulse with potential, awaiting a conductor to stabilise their harmony.",
+    "choices": [
+      {"command": "look", "description": "Observe the swirling resonance."},
+      {"command": "stabilize", "description": "Tune the sanctum's heart with your gathered relics."},
+      {"command": "return", "description": "Glide back toward the resonant bridge."},
+      {"command": "inventory", "description": "Check your belongings."},
+      {"command": "journal", "description": "Look over your recorded memories."},
+      {"command": "recall", "description": "Reflect on your recent decisions."},
+      {
+        "command": "guide",
+        "description": "Consult the field guide for lore (e.g. 'guide sanctum')."
+      }
+    ],
+    "transitions": {
+      "look": {
+        "narration": "Nebulous figures of past explorers shimmer at the chamber's edge, nodding encouragement as you arrive."
+      },
+      "stabilize": {
+        "narration": "You strike the resonant chime while presenting the ancient sigil. The currents align around you, locking the sanctum into a steady, radiant harmony.",
+        "records": ["Stabilised the sky sanctum"]
+      },
+      "return": {
+        "narration": "You drift back across the light bridge, the sanctum's glow lingering at your heels.",
+        "target": "resonant-bridge"
       }
     }
   }

--- a/src/textadventure/scripted_story_engine.py
+++ b/src/textadventure/scripted_story_engine.py
@@ -612,6 +612,18 @@ _DEFAULT_TOOLS: Mapping[str, Tool] = {
                 " suspended lenses. Only those who complete the bastion's"
                 " resonant trials can align its arrays."
             ),
+            "bridge": (
+                "The resonant bridge manifests only when the observatory's"
+                " pylons align. Ancient sigils stabilise the path, allowing"
+                " travellers to cross the starlit span without dissolving"
+                " into the night."
+            ),
+            "sanctum": (
+                "Legends speak of a sanctum above the spire where resonance"
+                " settles into harmony. Stabilising it requires both the"
+                " ancient sigil's authority and a chime tuned to the"
+                " bastion's heart."
+            ),
         },
     ),
 }

--- a/tests/data/golden_cli_walkthrough.txt
+++ b/tests/data/golden_cli_walkthrough.txt
@@ -325,13 +325,35 @@ The observatory dome opens to the stars. Arrays of lenses hang above a central d
 [guide] Consult the field guide for lore (e.g. 'guide observatory').
 You set the sunstone lens within the dais and ring the resonant chime. The pylons answer, harmonising with the night sky as pathways of light unfurl before you.
 
-[look] Gaze at the constellations.
-[activate] Channel the spire's energies.
-[reflect] Contemplate your journey.
-[return] Descend to the spire base.
+A ribbon of light arches from the observatory into the night, each step echoing with soft chimes that react to the sigil at your side.
+
+[look] Study the flowing constellations.
+[advance] Follow the luminous path toward the distant sanctum.
+[linger] Pause to absorb the surrounding harmony.
+[return] Ease back toward the observatory dais.
 [inventory] Check your belongings.
 [journal] Look over your recorded memories.
 [recall] Reflect on your recent decisions.
-[guide] Consult the field guide for lore (e.g. 'guide observatory').
+[guide] Consult the field guide for lore (e.g. 'guide bridge').
+The sigil glows in resonance, solidifying the path ahead as it carries you toward the sanctum suspended among the clouds.
+
+An airy chamber of starlit currents drifts above the spire. Crystalline pillars pulse with potential, awaiting a conductor to stabilise their harmony.
+
+[look] Observe the swirling resonance.
+[stabilize] Tune the sanctum's heart with your gathered relics.
+[return] Glide back toward the resonant bridge.
+[inventory] Check your belongings.
+[journal] Look over your recorded memories.
+[recall] Reflect on your recent decisions.
+[guide] Consult the field guide for lore (e.g. 'guide sanctum').
+You strike the resonant chime while presenting the ancient sigil. The currents align around you, locking the sanctum into a steady, radiant harmony.
+
+[look] Observe the swirling resonance.
+[stabilize] Tune the sanctum's heart with your gathered relics.
+[return] Glide back toward the resonant bridge.
+[inventory] Check your belongings.
+[journal] Look over your recorded memories.
+[recall] Reflect on your recent decisions.
+[guide] Consult the field guide for lore (e.g. 'guide sanctum').
 
 Thanks for playing!

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -292,6 +292,8 @@ def test_cli_walkthrough_matches_golden(monkeypatch, capsys) -> None:
             "return",
             "observatory",
             "activate",
+            "advance",
+            "stabilize",
             "quit",
         ]
     )

--- a/tests/test_scripted_story_engine.py
+++ b/tests/test_scripted_story_engine.py
@@ -286,6 +286,35 @@ def test_observatory_activation_requires_items() -> None:
     success_event = engine.propose_event(world, player_input="activate")
 
     assert "pathways of light" in success_event.narration.lower()
+    assert world.location == "resonant-bridge"
+    assert "ribbon of light arches" in success_event.narration.lower()
+
+
+def test_resonant_bridge_requires_sigil() -> None:
+    world = WorldState(location="resonant-bridge")
+    engine = ScriptedStoryEngine()
+
+    failure_event = engine.propose_event(world, player_input="advance")
+
+    assert "bridge frays" in failure_event.narration.lower()
+    assert world.location == "resonant-bridge"
+
+    world.add_item("ancient sigil")
+
+    success_event = engine.propose_event(world, player_input="advance")
+
+    assert world.location == "sky-sanctum"
+    assert "sigil glows" in success_event.narration.lower()
+
+
+def test_sky_sanctum_stabilize_records_history() -> None:
+    world = WorldState(location="sky-sanctum")
+    engine = ScriptedStoryEngine()
+
+    event = engine.propose_event(world, player_input="stabilize")
+
+    assert "currents align" in event.narration.lower()
+    assert "stabilised the sky sanctum" in "\n".join(world.history).lower()
 
 
 def test_archives_study_requires_map() -> None:


### PR DESCRIPTION
## Summary
- extend the scripted scene data with a resonant bridge finale that links the observatory to a new sky sanctum location
- add matching lore guide entries, regression tests, and CLI transcript coverage for the new path
- document the updated quest flow and mark the backlog item complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d9cfec152c832499e2e8a9f4d34c61