### PR TITLE
Add reachability analytics for scene graphs

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -316,6 +316,9 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Implement metrics utilities with automated tests.
         - [x] Provide a CLI/report helper for summarising the results.
       - [ ] Reachability statistics
+        - [x] Add analytics helpers to compute reachable and unreachable scenes from a starting location.
+        - [x] Surface a formatted reachability report alongside the existing complexity output.
+        - [x] Cover the new helpers with automated tests against sample scenes.
       - [ ] Content distribution analysis
       - [ ] Quality assessment tools
 

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -2,10 +2,15 @@
 
 from .analytics import (
     AdventureComplexityMetrics,
+    AdventureReachabilityReport,
     compute_adventure_complexity,
     compute_adventure_complexity_from_definitions,
     compute_adventure_complexity_from_file,
+    compute_scene_reachability,
+    compute_scene_reachability_from_definitions,
+    compute_scene_reachability_from_file,
     format_complexity_report,
+    format_reachability_report,
 )
 from .llm import LLMClient, LLMClientError, LLMMessage, LLMResponse, iter_contents
 from .llm_providers import (
@@ -47,10 +52,15 @@ __all__ = [
     "StoryEvent",
     "StoryEngine",
     "AdventureComplexityMetrics",
+    "AdventureReachabilityReport",
     "compute_adventure_complexity",
     "compute_adventure_complexity_from_definitions",
     "compute_adventure_complexity_from_file",
+    "compute_scene_reachability",
+    "compute_scene_reachability_from_definitions",
+    "compute_scene_reachability_from_file",
     "format_complexity_report",
+    "format_reachability_report",
     "ScriptedStoryEngine",
     "load_scenes_from_file",
     "load_scenes_from_mapping",


### PR DESCRIPTION
## Summary
- add a reachability report data structure and helpers to compute it from scripted scenes
- extend the analytics CLI to surface the reachability report alongside existing complexity metrics and accept a configurable start scene
- add automated tests covering reachability calculation, formatting, and error handling, and document progress in TASKS

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da1dce21a88324bff5c1fbd79929c5