### PR TITLE
Add quality assessment analytics for adventures

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -320,7 +320,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Surface a formatted reachability report alongside the existing complexity output.
         - [x] Cover the new helpers with automated tests against sample scenes.
       - [x] Content distribution analysis *(Added word/character distribution metrics across scenes, choices, transitions, failure narrations, and conditional overrides with CLI reporting.)*
-      - [ ] Quality assessment tools
+      - [x] Quality assessment tools
+        - [x] Define heuristics for identifying low-quality scene content.
+        - [x] Implement quality assessment reporting utilities and CLI output.
+        - [x] Cover the new quality checks with automated tests.
 
   - [ ] **Phase 9: Integration & Deployment**
     - [ ] Integrate editor with existing CLI workflow:


### PR DESCRIPTION
## Summary
- add heuristic quality assessment utilities that flag missing descriptions, narrations, and failure text in scripted adventures
- extend the analytics CLI to print a human-readable quality report alongside existing complexity, distribution, and reachability summaries
- cover the new analytics with targeted unit tests and update TASKS.md to reflect the completed work

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68def8cee4488324adbd70786e01270a