### PR TITLE
Add ANSI Markdown rendering for CLI narration

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -227,7 +227,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Rich text editor for narration
         - [ ] Evaluate rich text frameworks that output Markdown-compatible content
         - [x] Document requirements and integration plan *(see `docs/rich_text_editor_plan.md`)*
-        - [ ] Prototype Markdown rendering in the CLI runtime
+        - [x] Prototype Markdown rendering in the CLI runtime *(Added ANSI Markdown renderer and wired it into the CLI formatting flow.)*
         - [ ] Integrate the editor into the scene authoring UI shell
         - [ ] Add collaborative enhancements (presence indicators, inline comments)
       - [ ] Item requirements multi-select

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -32,6 +32,7 @@ from .scripted_story_engine import (
     load_scenes_from_file,
     load_scenes_from_mapping,
 )
+from .markdown import render_markdown
 from .multi_agent import (
     Agent,
     AgentTrigger,
@@ -84,6 +85,7 @@ __all__ = [
     "CoordinatorDebugState",
     "QueuedAgentMessage",
     "LLMStoryAgent",
+    "render_markdown",
     "Tool",
     "ToolResponse",
     "KnowledgeBaseTool",

--- a/src/textadventure/markdown.py
+++ b/src/textadventure/markdown.py
@@ -1,0 +1,133 @@
+"""Helpers for rendering Markdown-formatted narration to ANSI text."""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+ITALIC = "\033[3m"
+UNDERLINE = "\033[4m"
+FAINT = "\033[2m"
+CODE = "\033[38;5;214m"
+HEADING_COLOURS = {
+    1: "\033[95m",  # magenta
+    2: "\033[94m",  # blue
+    3: "\033[92m",  # green
+}
+BULLET_SYMBOL = "•"
+ORDERED_LIST_PATTERN = re.compile(r"^(\d+)[.)]\s+(.*)")
+LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+BOLD_PATTERN = re.compile(r"(\*\*|__)(.+?)\1")
+ITALIC_STAR_PATTERN = re.compile(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)")
+ITALIC_UNDERSCORE_PATTERN = re.compile(r"(?<!_)_(?!_)(.+?)(?<!_)_(?!_)")
+CODE_PATTERN = re.compile(r"`([^`]+)`")
+ESCAPED_CHAR_PATTERN = re.compile(r"\\([*_`\\])")
+
+
+def _strip_ansi_length(text: str) -> int:
+    """Return the printable length of ``text`` ignoring ANSI sequences."""
+
+    # ANSI escape codes follow ``\x1b[`` and end with ``m`` for the styles we emit.
+    return len(re.sub(r"\x1b\[[0-9;]*m", "", text))
+
+
+def _restore_escapes(text: str, escapes: Iterable[tuple[str, str]]) -> str:
+    """Replace temporary escape placeholders with their literal characters."""
+
+    for placeholder, original in escapes:
+        text = text.replace(placeholder, original)
+    return text
+
+
+def _apply_inline_styles(text: str) -> str:
+    """Apply inline Markdown formatting (bold, italics, code, links)."""
+
+    escapes: list[tuple[str, str]] = []
+
+    def _replace_escape(match: re.Match[str]) -> str:
+        placeholder = f"\uffff{len(escapes)}\uffff"
+        escapes.append((placeholder, match.group(1)))
+        return placeholder
+
+    text = ESCAPED_CHAR_PATTERN.sub(_replace_escape, text)
+
+    def _replace_code(match: re.Match[str]) -> str:
+        return f"{CODE}{match.group(1)}{RESET}"
+
+    text = CODE_PATTERN.sub(_replace_code, text)
+
+    def _replace_bold(match: re.Match[str]) -> str:
+        return f"{BOLD}{match.group(2)}{RESET}"
+
+    text = BOLD_PATTERN.sub(_replace_bold, text)
+
+    def _replace_italic(match: re.Match[str]) -> str:
+        return f"{ITALIC}{match.group(1)}{RESET}"
+
+    text = ITALIC_STAR_PATTERN.sub(_replace_italic, text)
+    text = ITALIC_UNDERSCORE_PATTERN.sub(_replace_italic, text)
+
+    def _replace_link(match: re.Match[str]) -> str:
+        label = match.group(1)
+        url = match.group(2)
+        styled_label = f"{UNDERLINE}{label}{RESET}"
+        return f"{styled_label} ({url})"
+
+    text = LINK_PATTERN.sub(_replace_link, text)
+
+    return _restore_escapes(text, escapes)
+
+
+def render_markdown(text: str) -> str:
+    """Render a Markdown string to ANSI-coloured text suitable for the CLI."""
+
+    lines = text.splitlines()
+    rendered: list[str] = []
+
+    for raw_line in lines:
+        if not raw_line.strip():
+            rendered.append("")
+            continue
+
+        stripped = raw_line.lstrip()
+        indent = " " * (len(raw_line) - len(stripped))
+
+        if stripped.startswith("#"):
+            level = len(stripped) - len(stripped.lstrip("#"))
+            content = stripped[level:].strip()
+            inline = _apply_inline_styles(content)
+            colour = HEADING_COLOURS.get(level, BOLD)
+            heading_text = f"{colour}{inline}{RESET}"
+            rendered.append(f"{indent}{heading_text}")
+            underline_char = "=" if level == 1 else "-" if level == 2 else "~"
+            underline = underline_char * max(_strip_ansi_length(inline), 1)
+            rendered.append(f"{indent}{underline}")
+            continue
+
+        if stripped.startswith("> "):
+            content = stripped[2:].strip()
+            inline = _apply_inline_styles(content)
+            rendered.append(f"{indent}{FAINT}> {inline}{RESET}")
+            continue
+
+        if stripped.startswith(("- ", "* ", "+ ")):
+            content = stripped[2:].strip()
+            inline = _apply_inline_styles(content)
+            rendered.append(f"{indent}{BULLET_SYMBOL} {inline}")
+            continue
+
+        ordered = ORDERED_LIST_PATTERN.match(stripped)
+        if ordered:
+            index, content = ordered.groups()
+            inline = _apply_inline_styles(content.strip())
+            rendered.append(f"{indent}{index}. {inline}")
+            continue
+
+        rendered.append(f"{indent}{_apply_inline_styles(stripped)}")
+
+    return "\n".join(rendered)
+
+
+__all__ = ["render_markdown"]

--- a/src/textadventure/story_engine.py
+++ b/src/textadventure/story_engine.py
@@ -10,6 +10,8 @@ from typing import Mapping, Sequence, Tuple, TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover - imported only for type checking
     from .world_state import WorldState
 
+from .markdown import render_markdown
+
 
 def _validate_text(value: str, *, field_name: str) -> str:
     """Validate and normalise free-form text fields used by story elements."""
@@ -101,11 +103,12 @@ class StoryEngine(ABC):
     def format_event(self, event: StoryEvent) -> str:
         """Create a printable representation of a story event."""
 
-        lines = [event.narration]
+        lines = [render_markdown(event.narration)]
         if event.choices:
             lines.append("")
             for choice in event.choices:
-                lines.append(f"[{choice.command}] {choice.description}")
+                description = render_markdown(choice.description)
+                lines.append(f"[{choice.command}] {description}")
         return "\n".join(lines)
 
 

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from textadventure.markdown import render_markdown
+
+
+def test_render_markdown_applies_inline_styles() -> None:
+    result = render_markdown("You find **bold** and *italic* plus `code`.")
+
+    assert "\033[1mbold\033[0m" in result
+    assert "\033[3mitalic\033[0m" in result
+    assert "\033[38;5;214mcode\033[0m" in result
+
+
+def test_render_markdown_handles_headings_and_lists() -> None:
+    text = """# Heading\n\n- First item\n- Second item"""
+
+    result = render_markdown(text)
+
+    assert "Heading" in result
+    assert "=" * len("Heading") in result
+    assert "• First item" in result
+    assert "• Second item" in result

--- a/tests/test_story_engine.py
+++ b/tests/test_story_engine.py
@@ -61,3 +61,16 @@ def test_story_engine_format_event() -> None:
     assert "[examine]" not in formatted
     assert "[look]" in formatted
     assert "Survey the area" in formatted
+
+
+def test_story_engine_format_event_renders_markdown() -> None:
+    engine = DummyStoryEngine()
+    event = StoryEvent(
+        narration="You witness **something** remarkable.",
+        choices=[StoryChoice("Inspect", "Study the *details* carefully.")],
+    )
+
+    formatted = engine.format_event(event)
+
+    assert "\033[1msomething\033[0m" in formatted
+    assert "\033[3mdetails\033[0m" in formatted


### PR DESCRIPTION
## Summary
- add a reusable Markdown-to-ANSI renderer for CLI narration output
- update the story engine formatter to render Markdown narration and choice text
- cover the renderer with unit tests and mark the CLI Markdown prototype task complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df1390fdec8324a56a81980055c433