### PR TITLE
Add item balance analysis to analytics reports

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -249,7 +249,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Source tracking (where items come from)
       - [ ] Usage tracking (where items are required)
       - [x] Orphaned item detection *(Implemented analytics helpers and CLI reporting for orphaned/unsourced items.)*
-      - [ ] Item balance analysis
+      - [x] Item balance analysis *(Added award/consumption balance classification and reporting.)*
 
   - [ ] **Phase 6: Live Preview & Testing**
     - [ ] Implement embedded adventure player:


### PR DESCRIPTION
## Summary
- extend the item flow analytics to calculate consumable balance information and expose surplus/deficit summaries in the formatted report
- cover the new item flow balance classification logic with dedicated unit tests
- update the tasks backlog to record the completed item balance analysis work

## Testing
- black src tests
- ruff check src tests
- pytest -q
- mypy src

------
https://chatgpt.com/codex/tasks/task_e_68df266e93b48324bae23a04edcfb969