### PR TITLE
Add API search filters for field type and validation status

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -297,7 +297,11 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [ ] **Phase 8: Quality of Life & Polish**
     - [ ] Implement comprehensive search:
       - [x] Global text search across all scenes *(Added search utilities and API endpoint for querying scene text with highlighted spans.)*
-      - [ ] Advanced filters (by type, validation status, etc.)
+      - [x] Advanced filters (by type, validation status, etc.) *(Search utilities now support field/scene filters and the API accepts comma-separated field type and validation filters with regression coverage.)*
+        - [x] Extend search utilities to support field-type and scene filters
+        - [x] Surface field-type filtering in the API/search endpoint
+        - [x] Add validation-status filtering support via the API
+        - [x] Expand tests covering the new filtering capabilities
       - [ ] Search and replace functionality
       - [ ] Reference finding
     - [ ] Add keyboard shortcuts and accessibility:

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -97,3 +97,30 @@ def test_search_rejects_empty_query() -> None:
 def test_search_from_definitions_helper() -> None:
     results = search_scene_text_from_definitions(_SAMPLE_DEFINITIONS, "torch")
     assert results.total_results == 1
+
+
+def test_search_scene_text_filters_allowed_field_types() -> None:
+    scenes = load_scenes_from_mapping(_SAMPLE_DEFINITIONS)
+
+    results = search_scene_text(
+        scenes,
+        "torch",
+        field_types=["choice_description"],
+    )
+
+    assert results.total_results == 1
+    scene_result = results.results[0]
+    assert scene_result.scene_id == "trail"
+    assert all(
+        match.field_type == "choice_description" for match in scene_result.matches
+    )
+
+
+def test_search_scene_text_filters_scene_ids() -> None:
+    scenes = load_scenes_from_mapping(_SAMPLE_DEFINITIONS)
+
+    only_trail = search_scene_text(scenes, "torch", allowed_scene_ids=["trail"])
+    assert {result.scene_id for result in only_trail.results} == {"trail"}
+
+    only_hall = search_scene_text(scenes, "torch", allowed_scene_ids=["hall"])
+    assert only_hall.total_results == 0


### PR DESCRIPTION
## Summary
- extend the core search helpers with optional field-type and scene filters
- parse comma-separated filtering parameters in the scene API and propagate them to the search service
- cover the new behaviour with API and unit tests while updating the backlog entry

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dfc5fbe3b083248255d92c7074bc9a