### PR TITLE
Add testing toolkit helpers for world state

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -258,7 +258,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] State tracking (location, inventory, history)
       - [ ] Reset and restart capabilities
     - [ ] Create testing toolkit:
-      - [ ] State manipulation tools (set inventory, history)
+      - [x] State manipulation tools (set inventory, history). *(Introduced `testing_toolkit` helpers for resetting inventory and history with regression tests.)*
       - [ ] Jump to specific scenes
       - [ ] Debug mode showing internal state
       - [ ] Step-by-step execution

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -74,6 +74,7 @@ from .persistence import (
 )
 from .memory import MemoryEntry, MemoryLog, MemoryRequest
 from .tools import KnowledgeBaseTool, Tool, ToolResponse
+from .testing_toolkit import set_history, set_inventory
 from .world_state import WorldState
 
 __all__ = [
@@ -133,6 +134,8 @@ __all__ = [
     "Tool",
     "ToolResponse",
     "KnowledgeBaseTool",
+    "set_inventory",
+    "set_history",
     "MemoryEntry",
     "MemoryLog",
     "MemoryRequest",

--- a/src/textadventure/testing_toolkit.py
+++ b/src/textadventure/testing_toolkit.py
@@ -1,0 +1,53 @@
+"""Helpers for manipulating ``WorldState`` instances during tests."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .world_state import WorldState
+
+
+__all__ = ["set_inventory", "set_history"]
+
+
+def set_inventory(
+    world: WorldState,
+    items: Iterable[str],
+    *,
+    record_events: bool = False,
+) -> None:
+    """Replace the inventory contents with the provided collection of items.
+
+    The helper removes any items that are not present in ``items`` and adds
+    any missing entries while respecting the original order of the iterable.
+    Duplicate values are ignored so the resulting inventory contains each item
+    at most once. When ``record_events`` is true the helper emits history
+    entries that mirror manual ``add_item``/``remove_item`` calls.
+    """
+
+    seen: set[str] = set()
+    target_order: list[str] = []
+    for raw_item in items:
+        validated = WorldState._validate_label(raw_item, "item")
+        if validated not in seen:
+            seen.add(validated)
+            target_order.append(validated)
+
+    target_items = set(target_order)
+    current_items = set(world.inventory)
+
+    for item in sorted(current_items - target_items):
+        world.remove_item(item, record_event=record_events)
+        current_items.remove(item)
+
+    for item in target_order:
+        if item not in current_items:
+            world.add_item(item, record_event=record_events)
+            current_items.add(item)
+
+
+def set_history(world: WorldState, events: Iterable[str]) -> None:
+    """Replace the history log with the supplied event descriptions."""
+
+    world.history.clear()
+    world.extend_history(events)

--- a/tests/test_testing_toolkit.py
+++ b/tests/test_testing_toolkit.py
@@ -1,0 +1,33 @@
+from textadventure.testing_toolkit import set_history, set_inventory
+from textadventure.world_state import WorldState
+
+
+def test_set_inventory_replaces_contents_without_history() -> None:
+    world = WorldState()
+    world.add_item("Lantern", record_event=False)
+    world.add_item("Compass", record_event=False)
+
+    set_inventory(world, ["Lantern", "Map", "Lantern"], record_events=False)
+
+    assert world.inventory == {"Lantern", "Map"}
+    assert world.history == []
+
+
+def test_set_inventory_records_changes_when_requested() -> None:
+    world = WorldState()
+    world.add_item("Lantern", record_event=False)
+    world.add_item("Compass", record_event=False)
+
+    set_inventory(world, ["Map", "Lantern"], record_events=True)
+
+    assert world.inventory == {"Lantern", "Map"}
+    assert world.history == ["Dropped Compass", "Picked up Map"]
+
+
+def test_set_history_replaces_event_log() -> None:
+    world = WorldState()
+    world.record_event("Original entry")
+
+    set_history(world, ["  First action  ", "Second action"])
+
+    assert world.history == ["First action", "Second action"]


### PR DESCRIPTION
## Summary
- add a testing toolkit module for adjusting world inventories and history during automated scenarios
- export the new helpers, exercise them with dedicated unit tests, and update the task backlog accordingly

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e07b986ec483249749890624424bc7