### PR TITLE
Add jump_to_scene helper to testing toolkit

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -259,7 +259,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Reset and restart capabilities
     - [ ] Create testing toolkit:
       - [x] State manipulation tools (set inventory, history). *(Introduced `testing_toolkit` helpers for resetting inventory and history with regression tests.)*
-      - [ ] Jump to specific scenes
+      - [x] Jump to specific scenes *(Added `jump_to_scene` helper for quickly moving the world state during tests with optional history recording.)*
       - [ ] Debug mode showing internal state
       - [ ] Step-by-step execution
     - [ ] Add WebSocket integration for live updates:

--- a/src/textadventure/testing_toolkit.py
+++ b/src/textadventure/testing_toolkit.py
@@ -7,7 +7,7 @@ from typing import Iterable
 from .world_state import WorldState
 
 
-__all__ = ["set_inventory", "set_history"]
+__all__ = ["set_inventory", "set_history", "jump_to_scene"]
 
 
 def set_inventory(
@@ -51,3 +51,20 @@ def set_history(world: WorldState, events: Iterable[str]) -> None:
 
     world.history.clear()
     world.extend_history(events)
+
+
+def jump_to_scene(
+    world: WorldState,
+    scene_id: str,
+    *,
+    record_event: bool = False,
+) -> None:
+    """Move ``world`` to ``scene_id`` without needing to play through choices.
+
+    The helper delegates to :meth:`WorldState.move_to` so validation rules are
+    preserved. Tests can opt-in to history tracking via ``record_event`` to
+    mirror real navigation, but the default leaves the history untouched so the
+    helper can be used for deterministic setup.
+    """
+
+    world.move_to(scene_id, record_event=record_event)

--- a/tests/test_testing_toolkit.py
+++ b/tests/test_testing_toolkit.py
@@ -1,4 +1,8 @@
-from textadventure.testing_toolkit import set_history, set_inventory
+from textadventure.testing_toolkit import (
+    jump_to_scene,
+    set_history,
+    set_inventory,
+)
 from textadventure.world_state import WorldState
 
 
@@ -31,3 +35,21 @@ def test_set_history_replaces_event_log() -> None:
     set_history(world, ["  First action  ", "Second action"])
 
     assert world.history == ["First action", "Second action"]
+
+
+def test_jump_to_scene_updates_location_without_history() -> None:
+    world = WorldState()
+
+    jump_to_scene(world, "mysterious-cavern")
+
+    assert world.location == "mysterious-cavern"
+    assert world.history == []
+
+
+def test_jump_to_scene_can_record_history() -> None:
+    world = WorldState()
+
+    jump_to_scene(world, "sunlit-grove", record_event=True)
+
+    assert world.location == "sunlit-grove"
+    assert world.history == ["Moved to sunlit-grove"]


### PR DESCRIPTION
## Summary
- add a jump_to_scene helper so tests can reposition the world state when preparing scenarios
- add unit tests demonstrating the helper with and without history recording
- update TASKS.md to mark the jump-to-scene tooling item as complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0894ec05483248651dd301153ddd7