### PR TITLE
Add debug snapshot helper for testing toolkit

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -260,7 +260,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
     - [ ] Create testing toolkit:
       - [x] State manipulation tools (set inventory, history). *(Introduced `testing_toolkit` helpers for resetting inventory and history with regression tests.)*
       - [x] Jump to specific scenes *(Added `jump_to_scene` helper for quickly moving the world state during tests with optional history recording.)*
-      - [ ] Debug mode showing internal state
+      - [x] Debug mode showing internal state *(Introduced `debug_snapshot` helper returning a structured `WorldDebugSnapshot` for assertions.)*
       - [ ] Step-by-step execution
     - [ ] Add WebSocket integration for live updates:
       - [ ] Real-time scene updates in preview

--- a/tests/test_testing_toolkit.py
+++ b/tests/test_testing_toolkit.py
@@ -1,4 +1,8 @@
+import pytest
+
 from textadventure.testing_toolkit import (
+    WorldDebugSnapshot,
+    debug_snapshot,
     jump_to_scene,
     set_history,
     set_inventory,
@@ -53,3 +57,34 @@ def test_jump_to_scene_can_record_history() -> None:
 
     assert world.location == "sunlit-grove"
     assert world.history == ["Moved to sunlit-grove"]
+
+
+def test_debug_snapshot_exposes_world_details() -> None:
+    world = WorldState()
+    world.move_to("sunlit-grove", record_event=False)
+    world.add_item("Lantern", record_event=False)
+    world.add_item("Compass", record_event=False)
+    world.record_event("Found a hidden alcove")
+    world.remember_action("look around")
+    world.remember_action("light lantern")
+    world.remember_observation("The cavern glows warmly.")
+
+    snapshot = debug_snapshot(world, action_limit=1)
+
+    assert snapshot == WorldDebugSnapshot(
+        location="sunlit-grove",
+        inventory=("Compass", "Lantern"),
+        history=("Found a hidden alcove",),
+        recent_actions=("light lantern",),
+        recent_observations=("The cavern glows warmly.",),
+    )
+
+
+def test_debug_snapshot_rejects_negative_limits() -> None:
+    world = WorldState()
+
+    with pytest.raises(ValueError):
+        debug_snapshot(world, action_limit=-1)
+
+    with pytest.raises(ValueError):
+        debug_snapshot(world, observation_limit=-2)


### PR DESCRIPTION
## Summary
- add a `WorldDebugSnapshot` dataclass and `debug_snapshot` helper to the testing toolkit
- cover the new helper with unit tests for expected output and validation errors
- update the project task list to mark the debug-mode tooling item as complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e08b2e98888324887b3cb6229c6048