### PR TITLE
Add step-through testing helper

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -261,7 +261,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [x] State manipulation tools (set inventory, history). *(Introduced `testing_toolkit` helpers for resetting inventory and history with regression tests.)*
       - [x] Jump to specific scenes *(Added `jump_to_scene` helper for quickly moving the world state during tests with optional history recording.)*
       - [x] Debug mode showing internal state *(Introduced `debug_snapshot` helper returning a structured `WorldDebugSnapshot` for assertions.)*
-      - [ ] Step-by-step execution
+      - [x] Step-by-step execution *(Added `step_through` helper and tests for scripted command execution with memory tracking.)*
     - [ ] Add WebSocket integration for live updates:
       - [ ] Real-time scene updates in preview
       - [ ] Collaborative editing indicators

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -74,7 +74,7 @@ from .persistence import (
 )
 from .memory import MemoryEntry, MemoryLog, MemoryRequest
 from .tools import KnowledgeBaseTool, Tool, ToolResponse
-from .testing_toolkit import set_history, set_inventory
+from .testing_toolkit import StepResult, set_history, set_inventory, step_through
 from .world_state import WorldState
 
 __all__ = [
@@ -136,6 +136,8 @@ __all__ = [
     "KnowledgeBaseTool",
     "set_inventory",
     "set_history",
+    "StepResult",
+    "step_through",
     "MemoryEntry",
     "MemoryLog",
     "MemoryRequest",


### PR DESCRIPTION
## Summary
- add a `step_through` helper with a `StepResult` dataclass for scripted command execution in tests
- export the new helper from the package and cover it with targeted unit tests
- mark the "Step-by-step execution" task as complete in the backlog

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0939436b08324bb4553ab5897203f