### PR TITLE
Add validation report endpoint to scene API

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -149,7 +149,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] `PUT /api/scenes/{scene_id}` - Update existing scene
       - [ ] `POST /api/scenes` - Create new scene
       - [ ] `DELETE /api/scenes/{scene_id}` - Delete scene (with dependency checks)
-      - [ ] `GET /api/scenes/validate` - Full integrity validation
+      - [x] `GET /api/scenes/validate` - Full integrity validation *(Added read-only endpoint returning quality, reachability, and item-flow summaries with test coverage.)*
       - [ ] `GET /api/scenes/graph` - Scene connectivity graph data
       - [ ] `POST /api/scenes/import` - Import JSON scene data
       - [ ] `GET /api/scenes/export` - Export current scenes as JSON


### PR DESCRIPTION
## Summary
- add pydantic resources to serialize aggregated validation data for scenes
- expose `GET /api/scenes/validate` to return quality, reachability, and item-flow summaries
- cover the new endpoint with FastAPI client tests and update the task tracker entry

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0958d57b48324ac18e7c4784b3e8f