### PR TITLE
Add API endpoint to export scene dataset

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -279,7 +279,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Conflict resolution (merge vs replace)
       - [ ] Backup creation before import
     - [ ] Implement export options:
-      - [ ] Full scene export
+      - [x] Full scene export *(Added `/api/export/scenes` endpoint returning the bundled dataset with timestamps.)*
       - [ ] Selective scene export
       - [ ] Minified vs pretty-printed JSON
       - [ ] Backup and versioning

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -195,6 +195,41 @@ Fetch the canonical definition for a single scene.
 
 - `404 Not Found` – Scene id unknown.
 
+### `GET /export/scenes`
+
+Download the full scripted scene dataset for offline editing, backup, or
+version control. The response mirrors the JSON structure stored on disk and
+includes the timestamp from the underlying resource.
+
+**Response – 200 OK**
+
+```json
+{
+  "generated_at": "2024-03-18T12:34:56Z",
+  "scenes": {
+    "village-square": {
+      "description": "You stand in the heart of the village…",
+      "choices": [
+        { "command": "talk", "description": "Chat with the townsfolk." }
+      ],
+      "transitions": {
+        "talk": {
+          "narration": "Villagers share rumors about the forest.",
+          "target": "forest-edge",
+          "records": ["Spoke with villagers"]
+        }
+      }
+    }
+  }
+}
+```
+
+**Notes**
+
+- Future enhancements may add query parameters for selective exports (scene
+  subsets, minified formatting) once the corresponding backlog items are
+  prioritised.
+
 ### `POST /scenes`
 
 Create a new scene. Requests provide the full scene payload except timestamps,


### PR DESCRIPTION
## Summary
- add a `SceneExportResponse`, service helper, and `/api/export/scenes` route that returns the bundled scene dataset with a timestamp
- document the export endpoint in the web editor API spec and mark the backlog item complete
- cover the new export route with unit tests validating the payload structure

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e09ee7fb8083248bb6d7ae5ecda07e