### PR TITLE
Add selective filtering to scene export endpoint

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -280,7 +280,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Backup creation before import
     - [ ] Implement export options:
       - [x] Full scene export *(Added `/api/export/scenes` endpoint returning the bundled dataset with timestamps.)*
-      - [ ] Selective scene export
+      - [x] Selective scene export
+        - [x] Support filtering `/api/export/scenes` by a comma-separated `ids` query parameter so only matching scenes are included.
+        - [x] Document the new selective export behaviour in the API specification.
+        - [x] Add regression tests covering filtered exports and error handling.
       - [ ] Minified vs pretty-printed JSON
       - [ ] Backup and versioning
     - [ ] Add version control integration:

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -197,9 +197,20 @@ Fetch the canonical definition for a single scene.
 
 ### `GET /export/scenes`
 
-Download the full scripted scene dataset for offline editing, backup, or
-version control. The response mirrors the JSON structure stored on disk and
-includes the timestamp from the underlying resource.
+Download the scripted scene dataset for offline editing, backup, or version
+control. The response mirrors the JSON structure stored on disk and includes
+the timestamp from the underlying resource.
+
+**Query parameters**
+
+- `ids` – Optional comma-separated list of scene identifiers to export. When
+  omitted the entire dataset is returned. Unknown identifiers result in a
+  `404 Not Found` response.
+
+**Examples**
+
+- `GET /export/scenes`
+- `GET /export/scenes?ids=starting-area,forest-edge`
 
 **Response – 200 OK**
 
@@ -223,12 +234,6 @@ includes the timestamp from the underlying resource.
   }
 }
 ```
-
-**Notes**
-
-- Future enhancements may add query parameters for selective exports (scene
-  subsets, minified formatting) once the corresponding backlog items are
-  prioritised.
 
 ### `POST /scenes`
 


### PR DESCRIPTION
## Summary
- add optional `ids` filtering to the `/api/export/scenes` endpoint and validate requested identifiers
- document the selective export workflow in the web editor API spec and mark the backlog item complete
- extend API tests to cover filtered exports and related error handling

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0a3a50c6c83248173a85491bf9bf5