### PR TITLE
Add formatting options to scene export API

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -282,9 +282,13 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [x] Full scene export *(Added `/api/export/scenes` endpoint returning the bundled dataset with timestamps.)*
       - [x] Selective scene export
         - [x] Support filtering `/api/export/scenes` by a comma-separated `ids` query parameter so only matching scenes are included.
-        - [x] Document the new selective export behaviour in the API specification.
-        - [x] Add regression tests covering filtered exports and error handling.
-      - [ ] Minified vs pretty-printed JSON
+      - [x] Document the new selective export behaviour in the API specification.
+      - [x] Add regression tests covering filtered exports and error handling.
+      - [x] Minified vs pretty-printed JSON
+        - [x] Add an API option to request minified or pretty-printed payloads.
+        - [x] Ensure the service layer produces the requested formatting.
+        - [x] Document the formatting option in the API reference.
+        - [x] Add automated tests covering both formatting modes.
       - [ ] Backup and versioning
     - [ ] Add version control integration:
       - [ ] Git-style change tracking

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -206,11 +206,15 @@ the timestamp from the underlying resource.
 - `ids` – Optional comma-separated list of scene identifiers to export. When
   omitted the entire dataset is returned. Unknown identifiers result in a
   `404 Not Found` response.
+- `format` – Optional export formatting flag. Accepts `minified` (default) for
+  compact output or `pretty` for indented JSON that is easier to review
+  manually.
 
 **Examples**
 
 - `GET /export/scenes`
 - `GET /export/scenes?ids=starting-area,forest-edge`
+- `GET /export/scenes?format=pretty`
 
 **Response – 200 OK**
 

--- a/src/fastapi/testclient.py
+++ b/src/fastapi/testclient.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
 from typing import Any, Mapping
@@ -10,12 +11,19 @@ from .app import FastAPI, HTTPException
 
 
 class _Response:
-    def __init__(self, status_code: int, payload: Any) -> None:
+    def __init__(self, status_code: int, payload: Any, text: str | None = None) -> None:
         self.status_code = status_code
         self._payload = payload
+        self._text = text
 
     def json(self) -> Any:
         return self._payload
+
+    @property
+    def text(self) -> str:
+        if self._text is not None:
+            return self._text
+        return json.dumps(self._payload)
 
 
 class TestClient:
@@ -32,21 +40,35 @@ class TestClient:
         except HTTPException as exc:
             return _Response(exc.status_code, {"detail": exc.detail})
 
-        payload = _serialise(result)
-        return _Response(200, payload)
+        payload, text = _serialise(result)
+        return _Response(200, payload, text)
 
 
-def _serialise(value: Any) -> Any:
+def _serialise(value: Any) -> tuple[Any, str | None]:
+    if hasattr(value, "body"):
+        body = getattr(value, "body")
+        if isinstance(body, (bytes, bytearray)):
+            text = body.decode("utf-8")
+        else:
+            text = str(body)
+
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            payload = text
+
+        return payload, text
+
     if hasattr(value, "model_dump"):
-        return value.model_dump(mode="json")  # type: ignore[call-arg]
+        return value.model_dump(mode="json"), None  # type: ignore[call-arg]
     if is_dataclass(value) and not isinstance(value, type):
-        return asdict(value)
+        return asdict(value), None
     if isinstance(value, list):
-        return [_serialise(item) for item in value]
+        return [_serialise(item)[0] for item in value], None
     if isinstance(value, tuple):
-        return [_serialise(item) for item in value]
+        return [_serialise(item)[0] for item in value], None
     if isinstance(value, dict):
-        return {key: _serialise(item) for key, item in value.items()}
+        return {key: _serialise(item)[0] for key, item in value.items()}, None
     if isinstance(value, datetime):
-        return value.isoformat()
-    return value
+        return value.isoformat(), None
+    return value, None


### PR DESCRIPTION
## Summary
- add an `ExportFormat` enum and custom JSON response so `/api/export/scenes` can return minified or pretty-formatted payloads
- teach the shimmed `fastapi.TestClient` to capture response bodies for assertions
- document the new `format` query parameter and cover both formatting styles with unit tests

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0ab74c9788324b23b35f8139bdb18