### PR TITLE
Add backup metadata to scene export

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -289,7 +289,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Ensure the service layer produces the requested formatting.
         - [x] Document the formatting option in the API reference.
         - [x] Add automated tests covering both formatting modes.
-      - [ ] Backup and versioning
+      - [x] Backup and versioning *(Export payload now includes deterministic version ids, checksums, and suggested backup filenames.)*
     - [ ] Add version control integration:
       - [ ] Git-style change tracking
       - [ ] Diff visualization

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -198,8 +198,9 @@ Fetch the canonical definition for a single scene.
 ### `GET /export/scenes`
 
 Download the scripted scene dataset for offline editing, backup, or version
-control. The response mirrors the JSON structure stored on disk and includes
-the timestamp from the underlying resource.
+control. The response mirrors the JSON structure stored on disk, includes the
+timestamp from the underlying resource, and now surfaces backup metadata that
+helps with file naming and integrity verification.
 
 **Query parameters**
 
@@ -235,6 +236,11 @@ the timestamp from the underlying resource.
         }
       }
     }
+  },
+  "metadata": {
+    "version_id": "20240318T123456Z-1a2b3c4d",
+    "checksum": "0a1b2c3d4e5f67890123456789abcdef0a1b2c3d4e5f67890123456789abcdef",
+    "suggested_filename": "scene-backup-20240318T123456Z-1a2b3c4d.json"
   }
 }
 ```


### PR DESCRIPTION
## Summary
- add deterministic version and checksum metadata to scene export responses for backup support
- document the new export metadata and cover it with API tests
- update the task backlog to reflect the completed backup and versioning work

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e0afe342c48324a1c954640cf7e0e5