### PR TITLE
Add schema migration support for scene imports

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -275,7 +275,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [ ] **Phase 7: Import/Export & File Management**
     - [ ] Build robust JSON import system:
       - [x] File upload with validation *(Implemented `/api/import/scenes` to accept JSON uploads, validate structure, and surface reachability/quality reports for the uploaded dataset.)*
-      - [ ] Schema migration support
+      - [x] Schema migration support *(Import endpoint accepts `schema_version` and migrates legacy v1 datasets before validation.)*
       - [ ] Conflict resolution (merge vs replace)
       - [ ] Backup creation before import
     - [ ] Implement export options:

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -245,6 +245,56 @@ helps with file naming and integrity verification.
 }
 ```
 
+
+### `POST /import/scenes`
+
+Validate an uploaded dataset prior to applying it to the live store. The
+endpoint performs structural validation, reachability analysis, and analytics
+checks without mutating the bundled JSON file. It also accepts legacy
+``schema_version`` payloads and migrates them to the current structure so older
+editor exports remain compatible.
+
+**Request body**
+
+```json
+{
+  "scenes": { /* Mapping of scene ids to definitions */ },
+  "schema_version": 1,
+  "start_scene": "village-square"
+}
+```
+
+**Fields**
+
+- `scenes` *(required)* – Mapping of identifiers to scene definitions.
+- `schema_version` *(optional)* – Positive integer indicating the schema the
+  payload conforms to. When omitted it defaults to the current server version.
+  Legacy datasets (currently version `1`) are migrated automatically. Requests
+  specifying a newer schema version than the server supports result in a
+  `400 Bad Request` response with a descriptive message.
+- `start_scene` *(optional)* – Scene identifier to seed reachability
+  calculations. Defaults to the first scene in the payload when omitted.
+
+**Response – 200 OK**
+
+```json
+{
+  "scene_count": 42,
+  "start_scene": "village-square",
+  "validation": {
+    "generated_at": "2024-04-01T09:00:00Z",
+    "reachability": {
+      "start_scene": "village-square",
+      "reachable_count": 42,
+      "unreachable": []
+    },
+    "quality": { /* See validation report definition */ },
+    "item_flow": { /* Item flow summary */ }
+  }
+}
+```
+
+
 ### `POST /scenes`
 
 Create a new scene. Requests provide the full scene payload except timestamps,


### PR DESCRIPTION
## Summary
- add schema version handling to the import validation workflow with a migration path for legacy v1 datasets
- extend API tests to cover successful migration and rejection of newer schema versions
- document the new schema_version request field and mark the backlog task as complete

## Testing
- ruff check src tests
- black src tests
- mypy src
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e0ffdb69b08324acae321e6879316a