### PR TITLE
Add import strategy plans to scene validation

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -276,7 +276,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
     - [ ] Build robust JSON import system:
       - [x] File upload with validation *(Implemented `/api/import/scenes` to accept JSON uploads, validate structure, and surface reachability/quality reports for the uploaded dataset.)*
       - [x] Schema migration support *(Import endpoint accepts `schema_version` and migrates legacy v1 datasets before validation.)*
-      - [ ] Conflict resolution (merge vs replace)
+      - [x] Conflict resolution (merge vs replace) *(Import validation now reports merge vs replace change plans to highlight updates, additions, and removals.)*
       - [ ] Backup creation before import
     - [ ] Implement export options:
       - [x] Full scene export *(Added `/api/export/scenes` endpoint returning the bundled dataset with timestamps.)*

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -290,9 +290,36 @@ editor exports remain compatible.
     },
     "quality": { /* See validation report definition */ },
     "item_flow": { /* Item flow summary */ }
-  }
+  },
+  "plans": [
+    {
+      "strategy": "merge",
+      "new_scene_ids": ["market-square"],
+      "updated_scene_ids": ["village-square"],
+      "unchanged_scene_ids": ["forest-edge"],
+      "removed_scene_ids": []
+    },
+    {
+      "strategy": "replace",
+      "new_scene_ids": ["market-square"],
+      "updated_scene_ids": ["village-square"],
+      "unchanged_scene_ids": ["forest-edge"],
+      "removed_scene_ids": ["docks"]
+    }
+  ]
 }
 ```
+
+The `plans` array outlines how the uploaded dataset would affect the current
+store for each supported conflict resolution strategy:
+
+- `merge` retains scenes that are absent from the upload, highlighting which
+  existing scenes would be updated by the incoming data.
+- `replace` swaps the entire dataset, listing which scenes would be removed in
+  the process.
+
+Clients can present these plans to authors before committing the import so
+they can choose the most appropriate strategy for their project.
 
 
 ### `POST /scenes`


### PR DESCRIPTION
## Summary
- add import strategy planning models so the validation endpoint reports merge and replace outcomes
- compute change plans by comparing uploaded scenes with the bundled dataset and include them in the response
- document the new response shape, cover it with tests, and mark the backlog item complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1028e1eac83248d8d5d8f3eac68a8