### PR TITLE
Add HTML diff visualisation to scene diff endpoint

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -298,7 +298,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Add API endpoint providing scene dataset diff summaries
         - [x] Document the diff workflow in the API reference
         - [x] Cover diff computation with automated tests
-      - [ ] Diff visualization
+      - [x] Diff visualization *(API now returns HTML diff tables alongside unified diffs with documentation and tests.)*
+        - [x] Provide HTML-rendered diff fragments from the API for changed scenes.
+        - [x] Document the diff visualisation field in the API specification.
+        - [x] Add regression tests covering the HTML diff output.
       - [ ] Rollback capabilities
       - [ ] Branch management for different storylines
     - [ ] Create project management features:

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -363,17 +363,20 @@ each changed scene so editors can render inline previews.
     {
       "scene_id": "village-square",
       "status": "modified",
-      "diff": "--- current/village-square\n+++ incoming/village-square\n@@\n-  \"description\": \"A quiet square.\"\n+  \"description\": \"The square buzzes with activity.\"\n"
+      "diff": "--- current/village-square\n+++ incoming/village-square\n@@\n-  \"description\": \"A quiet square.\"\n+  \"description\": \"The square buzzes with activity.\"\n",
+      "diff_html": "<table class=\"diff\">…</table>"
     },
     {
       "scene_id": "docks",
       "status": "removed",
-      "diff": "--- current/docks\n@@\n-  \"description\": \"Ships bob in the harbour.\"\n"
+      "diff": "--- current/docks\n@@\n-  \"description\": \"Ships bob in the harbour.\"\n",
+      "diff_html": "<table class=\"diff\">…</table>"
     },
     {
       "scene_id": "market-square",
       "status": "added",
-      "diff": "+++ incoming/market-square\n@@\n+  \"description\": \"Merchants line the stalls.\"\n"
+      "diff": "+++ incoming/market-square\n@@\n+  \"description\": \"Merchants line the stalls.\"\n",
+      "diff_html": "<table class=\"diff\">…</table>"
     }
   ]
 }
@@ -381,8 +384,10 @@ each changed scene so editors can render inline previews.
 
 Clients can use the summary lists to power change indicators (e.g. sidebars or
 status badges) while rendering the unified diffs inline for detailed review. The
-response intentionally mirrors Git conventions so future tooling can extend it
-with syntax highlighting or patch application.
+`diff_html` payload offers a ready-to-render table produced by
+`difflib.HtmlDiff`, making it easy to drop into the editor UI with a small CSS
+stylesheet. The response intentionally mirrors Git conventions so future
+tooling can extend it with syntax highlighting or patch application.
 
 
 ### `POST /scenes`

--- a/tests/test_api_scenes.py
+++ b/tests/test_api_scenes.py
@@ -849,14 +849,20 @@ def test_diff_scenes_reports_added_removed_and_modified_entries() -> None:
     assert "+++ incoming/beta" in beta_diff["diff"]
     assert '-  "description": "Beta original"' in beta_diff["diff"]
     assert '+  "description": "Beta updated"' in beta_diff["diff"]
+    assert beta_diff["diff_html"].startswith("<table")
+    assert "diff_chg" in beta_diff["diff_html"] or "diff_add" in beta_diff["diff_html"]
 
     gamma_diff = entries_by_scene["gamma"]
     assert gamma_diff["status"] == "removed"
     assert gamma_diff["diff"].startswith("--- current/gamma")
+    assert gamma_diff["diff_html"].startswith("<table")
+    assert "diff_sub" in gamma_diff["diff_html"]
 
     delta_diff = entries_by_scene["delta"]
     assert delta_diff["status"] == "added"
     assert "+++ incoming/delta" in delta_diff["diff"]
+    assert delta_diff["diff_html"].startswith("<table")
+    assert "diff_add" in delta_diff["diff_html"]
 
 
 def test_diff_scenes_returns_unchanged_summary_when_payload_matches() -> None:


### PR DESCRIPTION
## Summary
- add HTML diff tables to `SceneDiffEntry` responses so UIs can render visual change previews
- document the new `diff_html` payload in the web editor API spec and mark the diff visualisation task complete
- extend API regression tests to cover the HTML diff output

## Testing
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e19fbc85888324b61198b8dd7fe029