### PR TITLE
Add rollback planning endpoint

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -302,7 +302,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Provide HTML-rendered diff fragments from the API for changed scenes.
         - [x] Document the diff visualisation field in the API specification.
         - [x] Add regression tests covering the HTML diff output.
-      - [ ] Rollback capabilities
+      - [x] Rollback capabilities *(Added `/api/scenes/rollback` planning endpoint with version metadata, diffs, and replace strategy coverage.)*
       - [ ] Branch management for different storylines
     - [ ] Create project management features:
       - [ ] Multiple adventure projects


### PR DESCRIPTION
## Summary
- add rollback planning API models and endpoint for scene backups
- share diff computation helpers and expose rollback planning on the service
- document the new workflow and cover it with unit tests while updating the backlog

## Testing
- `pytest -q`
- `mypy src`
- `ruff check src tests`


------
https://chatgpt.com/codex/tasks/task_e_68e1a1b2be7c8324b1490f66f417d980