### PR TITLE
Add interactive tutorial command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ integration.
 - **Interactive CLI demo** – `src/main.py` wires the story engine, world state,
   persistence, optional transcript logging, and the LLM provider registry into a
   small playable loop.
+- **Guided onboarding** – Enter `tutorial` inside the CLI to walk through the
+  core commands, persistence options, and debugging tools at your own pace.
 - **Rich world modelling** – `WorldState` tracks locations, actors, inventory,
   remembered observations, and player actions.
 - **Story engines** – the `StoryEngine` protocol defines how narrative beats
@@ -77,7 +79,10 @@ TASKS.md                   # Planning notes and backlog ideas
   provider with repeated `--llm-option` flags (for example,
   `--llm-provider openai --llm-option api_key=...`). Alternatively pass
   `--llm-config path/to/config.json` to load the provider identifier and
-  options from a JSON file. A more detailed walkthrough covering environment
+  options from a JSON file. Once the adventure starts, type `help` for a
+  summary of system commands or `tutorial` to follow an interactive walkthrough
+  covering choices, status, saving, and quitting. A more detailed walkthrough
+  covering environment
   setup, optional features, and troubleshooting lives in
   [`docs/getting_started.md`](docs/getting_started.md).
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -329,7 +329,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Screen reader support
       - [ ] High contrast mode
     - [ ] Create help system:
-      - [ ] Interactive tutorials
+      - [x] Interactive tutorials *(Added a CLI `tutorial` command with a guided walkthrough covering choices, system commands, and persistence tips.)*
       - [x] Context-sensitive help *(Added a CLI `help` command that surfaces current story choices alongside system command guidance.)*
       - [x] Best practices guide *(Documented adventure design guidance in `docs/best_practices.md` and linked it from the README.)*
       - [x] Troubleshooting documentation *(Added `docs/troubleshooting.md` and linked it from the README troubleshooting section.)*

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -68,8 +68,8 @@ services.
 - **CLI runtime (`src/main.py`)** – `run_cli` wires together a story engine,
   world state, optional session store, and transcript logging. The embedded
   `TranscriptLogger` records narration, choices, metadata, and player commands for
-  debugging, while commands such as `help`, `status`, `save`, and `load` expose
-  runtime management features.
+  debugging, while commands such as `help`, `tutorial`, `status`, `save`, and `load`
+  expose runtime management features.
 
 ## Tooling, Analytics, and Search
 - **Tool abstractions (`textadventure.tools`)** – Define the base `Tool` interface

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -9,7 +9,8 @@ the system for new adventures or agent behaviours.
 1. **Entry point** – `src/main.py` wires the world state, story engine, optional
    persistence, optional LLM providers, and an interactive CLI loop. It prints
    story events using `StoryEngine.format_event`, handles commands such as
-   `save`, `load`, and `status`, and records transcripts when requested.
+   `help`, `tutorial`, `save`, `load`, and `status`, and records transcripts when
+   requested.
 2. **World state** – `WorldState` stores the player's location, inventory,
    history, and a rolling `MemoryLog`. Helper methods validate inputs, record
    events, and expose recent actions/observations to agents.

--- a/docs/feature_reference.md
+++ b/docs/feature_reference.md
@@ -7,10 +7,11 @@ is available and where to look next.
 ## Interactive CLI Adventure
 
 - The CLI welcomes players, prints the current story beat, and accepts free-form
-  input until the narrative reaches a natural ending.【F:src/main.py†L70-L215】
-- Built-in commands include `save <id>`, `load <id>`, and `status`, providing
-  quick persistence controls and a live snapshot of the world, queued agent
-  messages, and known save files.【F:src/main.py†L139-L212】
+  input until the narrative reaches a natural ending.【F:src/main.py†L208-L354】
+- Built-in commands include `save <id>`, `load <id>`, `status`, and `tutorial`,
+  providing quick persistence controls, a live snapshot of the world, queued
+  agent messages, known save files, and an interactive walkthrough for new
+  players.【F:src/main.py†L239-L363】
 - Command-line flags configure persistence, transcript logging, and LLM
   co-narrators (see `--session-dir`, `--log-file`, `--llm-provider`,
   `--llm-config`, and repeated `--llm-option key=value`).【F:src/main.py†L218-L268】

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,7 @@ Launch the scripted text adventure from the repository root:
 python src/main.py
 ```
 
-The CLI will print the current scene narration, available choices, and a prompt for your next command. Enter `help` to see built-in commands such as `save`, `load`, `status`, and `quit`.
+The CLI will print the current scene narration, available choices, and a prompt for your next command. Enter `help` to see built-in commands such as `save`, `load`, `status`, and `quit`, or type `tutorial` for an interactive walkthrough of the same features.
 
 ### Enable Persistence and Logging
 

--- a/tests/data/golden_cli_walkthrough.txt
+++ b/tests/data/golden_cli_walkthrough.txt
@@ -1,5 +1,6 @@
 Welcome to the Text Adventure prototype!
 Type 'quit' at any time to end the session.
+Type 'help' for a command overview or 'tutorial' for a guided tour.
 
 Sunlight filters through tall trees at the forest trailhead. An old stone gate lies to the north, while flag-marked paths lead toward a scavenger camp and a ranger lookout.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,6 +153,43 @@ def test_run_cli_informs_when_saving_unavailable(monkeypatch, capsys) -> None:
     assert world.recent_actions() == ()
 
 
+def test_tutorial_command_walks_through_steps(monkeypatch, capsys) -> None:
+    """The tutorial command should provide an interactive walkthrough."""
+
+    engine = ScriptedStoryEngine()
+    world = WorldState()
+
+    inputs = iter(["tutorial", "", "", "", "", "quit"])
+    monkeypatch.setattr(builtins, "input", _IteratorInput(inputs))
+
+    run_cli(engine, world)
+
+    captured = capsys.readouterr().out
+    assert "=== Interactive Tutorial ===" in captured
+    assert "Step 1 of" in captured
+    assert "Use the CLI helpers" in captured
+    assert "Remember that 'help' and 'tutorial'" in captured
+    assert world.recent_actions() == ()
+
+
+def test_tutorial_command_mentions_saving_when_available(monkeypatch, capsys) -> None:
+    """When persistence is enabled, the tutorial should highlight save/load."""
+
+    engine = ScriptedStoryEngine()
+    world = WorldState()
+    store = InMemorySessionStore()
+
+    inputs = iter(["tutorial", "", "", "", "", "quit"])
+    monkeypatch.setattr(builtins, "input", _IteratorInput(inputs))
+
+    run_cli(engine, world, session_store=store)
+
+    captured = capsys.readouterr().out
+    assert "Save your progress at any time" in captured
+    assert "also appear in the 'status' command." in captured
+    assert world.recent_actions() == ()
+
+
 def test_run_cli_autoloads_session(monkeypatch, capsys) -> None:
     """Providing autoload details should restore the world before the loop."""
 


### PR DESCRIPTION
## Summary
- add a CLI TutorialGuide that walks players through the core commands and persistence options
- surface the new tutorial command in help output, documentation, and the golden CLI transcript
- cover the tutorial flow with new pytest cases and mark the related TASKS.md item complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1a6abfdc48324bcc5071f08039873