### PR TITLE
Persist branch definitions via API endpoints

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -306,7 +306,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Branch management for different storylines
         - [x] Add an API branch planning endpoint that surfaces diffs, version metadata, and merge vs replace strategies with tests.
         - [x] Document the branch planning workflow in the API specification.
-        - [ ] Persist branch definitions and expose listing/creation endpoints.
+        - [x] Persist branch definitions and expose listing/creation endpoints.
+          - [x] Design a storage format and repository for saved branch definitions.
+          - [x] Implement API endpoints to list and create branch definitions backed by the repository.
+          - [x] Add automated tests and documentation updates covering the new branch persistence workflow.
     - [ ] Create project management features:
       - [ ] Multiple adventure projects
       - [ ] Project templates

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -539,6 +539,88 @@ before creating the branch.
 }
 ```
 
+### `GET /scenes/branches`
+
+Return the list of branch definitions that have been saved through the API.
+Responses are sorted by creation time (most recent first) and surface summary
+metadata for rendering selection menus or project dashboards.
+
+**Response – 200 OK**
+
+```json
+{
+  "data": [
+    {
+      "id": "hidden-door-path",
+      "name": "Hidden Door Path",
+      "created_at": "2024-07-02T09:20:00Z",
+      "base": {
+        "generated_at": "2024-07-01T12:00:00Z",
+        "version_id": "20240701T120000Z-1a2b3c4d",
+        "checksum": "f3a8…"
+      },
+      "target": {
+        "generated_at": "2024-07-02T09:15:00Z",
+        "version_id": "20240702T091500Z-5e6f7a8b",
+        "checksum": "4b91…"
+      },
+      "expected_base_version_id": "20240701T120000Z-1a2b3c4d",
+      "base_version_matches": true,
+      "summary": {
+        "added_scene_ids": ["hidden-door"],
+        "removed_scene_ids": [],
+        "modified_scene_ids": ["alpha"],
+        "unchanged_scene_ids": ["beta"]
+      },
+      "scene_count": 2
+    }
+  ]
+}
+```
+
+### `POST /scenes/branches`
+
+Persist a branch definition so it can be revisited later or imported into a
+story project. The request mirrors `POST /scenes/branches/plan`, but storing the
+definition assigns it a stable identifier and records when it was saved.
+
+**Request body** – Same structure as `POST /scenes/branches/plan`.
+
+**Responses**
+
+- `201 Created`
+
+  ```json
+  {
+    "id": "hidden-door-path",
+    "name": "Hidden Door Path",
+    "created_at": "2024-07-02T09:20:00Z",
+    "base": {
+      "generated_at": "2024-07-01T12:00:00Z",
+      "version_id": "20240701T120000Z-1a2b3c4d",
+      "checksum": "f3a8…"
+    },
+    "target": {
+      "generated_at": "2024-07-02T09:15:00Z",
+      "version_id": "20240702T091500Z-5e6f7a8b",
+      "checksum": "4b91…"
+    },
+    "expected_base_version_id": "20240701T120000Z-1a2b3c4d",
+    "base_version_matches": true,
+    "summary": {
+      "added_scene_ids": ["hidden-door"],
+      "removed_scene_ids": [],
+      "modified_scene_ids": ["alpha"],
+      "unchanged_scene_ids": ["beta"]
+    },
+    "scene_count": 2
+  }
+  ```
+
+- `400 Bad Request` – Payload fails validation (missing branch name, invalid
+  schema version, or scene definitions that cannot be migrated).
+- `409 Conflict` – A branch with the derived identifier already exists.
+
 ### `POST /scenes`
 
 Create a new scene. Requests provide the full scene payload except timestamps,

--- a/src/fastapi/testclient.py
+++ b/src/fastapi/testclient.py
@@ -36,12 +36,12 @@ class TestClient:
 
     def get(self, path: str, params: Mapping[str, Any] | None = None) -> _Response:
         try:
-            result = self._app._dispatch("GET", path, params or {})
+            result, status = self._app._dispatch("GET", path, params or {})
         except HTTPException as exc:
             return _Response(exc.status_code, {"detail": exc.detail})
 
         payload, text = _serialise(result)
-        return _Response(200, payload, text)
+        return _Response(status, payload, text)
 
     def post(
         self,
@@ -50,12 +50,12 @@ class TestClient:
         json: Any | None = None,
     ) -> _Response:
         try:
-            result = self._app._dispatch("POST", path, params or {}, json)
+            result, status = self._app._dispatch("POST", path, params or {}, json)
         except HTTPException as exc:
             return _Response(exc.status_code, {"detail": exc.detail})
 
         payload, text = _serialise(result)
-        return _Response(200, payload, text)
+        return _Response(status, payload, text)
 
 
 def _serialise(value: Any) -> tuple[Any, str | None]:


### PR DESCRIPTION
## Summary
- add a filesystem-backed store for scene branch definitions and expose new list/create service methods and API routes
- extend the FastAPI test doubles so routes can specify status codes and update tests to cover branch persistence flows
- document the new branch endpoints in the web editor API spec and mark the related backlog tasks complete

## Testing
- `black src tests`
- `ruff check src tests`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e1b4f1b0a8832491f5126add7f0f72