### PR TITLE
Add branch retrieval and deletion endpoints

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -303,13 +303,16 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Document the diff visualisation field in the API specification.
         - [x] Add regression tests covering the HTML diff output.
       - [x] Rollback capabilities *(Added `/api/scenes/rollback` planning endpoint with version metadata, diffs, and replace strategy coverage.)*
-      - [ ] Branch management for different storylines
+      - [x] Branch management for different storylines
         - [x] Add an API branch planning endpoint that surfaces diffs, version metadata, and merge vs replace strategies with tests.
         - [x] Document the branch planning workflow in the API specification.
         - [x] Persist branch definitions and expose listing/creation endpoints.
           - [x] Design a storage format and repository for saved branch definitions.
           - [x] Implement API endpoints to list and create branch definitions backed by the repository.
           - [x] Add automated tests and documentation updates covering the new branch persistence workflow.
+        - [x] Provide an API endpoint to retrieve saved branch definitions including metadata, plans, and scenes.
+        - [x] Support deleting saved branch definitions via the API with filesystem persistence cleanup.
+        - [x] Document the retrieval and deletion workflows and add regression tests.
     - [ ] Create project management features:
       - [ ] Multiple adventure projects
       - [ ] Project templates

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -578,6 +578,98 @@ metadata for rendering selection menus or project dashboards.
 }
 ```
 
+### `GET /scenes/branches/{branch_id}`
+
+Fetch the full branch definition so editors can review the diff metadata,
+available import strategies, and the saved scene payloads before applying or
+sharing the branch.
+
+**Path parameters**
+
+- `branch_id` – Stable identifier returned by `POST /scenes/branches`.
+
+**Response – 200 OK**
+
+```json
+{
+  "id": "hidden-door-path",
+  "name": "Hidden Door Path",
+  "created_at": "2024-07-02T09:20:00Z",
+  "base": {
+    "generated_at": "2024-07-01T12:00:00Z",
+    "version_id": "20240701T120000Z-1a2b3c4d",
+    "checksum": "f3a8…"
+  },
+  "target": {
+    "generated_at": "2024-07-02T09:15:00Z",
+    "version_id": "20240702T091500Z-5e6f7a8b",
+    "checksum": "4b91…"
+  },
+  "expected_base_version_id": "20240701T120000Z-1a2b3c4d",
+  "base_version_matches": true,
+  "summary": {
+    "added_scene_ids": ["hidden-door"],
+    "removed_scene_ids": [],
+    "modified_scene_ids": ["alpha"],
+    "unchanged_scene_ids": ["beta"]
+  },
+  "scene_count": 2,
+  "entries": [
+    {
+      "scene_id": "alpha",
+      "status": "modified",
+      "diff": "--- current/alpha\n+++ branch/alpha\n…",
+      "diff_html": "<table class=\"diff\">…</table>"
+    },
+    {
+      "scene_id": "hidden-door",
+      "status": "added",
+      "diff": "+++ branch/hidden-door\n…",
+      "diff_html": "<table class=\"diff\">…</table>"
+    }
+  ],
+  "plans": [
+    {
+      "strategy": "merge",
+      "new_scene_ids": ["hidden-door"],
+      "updated_scene_ids": ["alpha"],
+      "unchanged_scene_ids": ["beta"],
+      "removed_scene_ids": []
+    },
+    {
+      "strategy": "replace",
+      "new_scene_ids": ["hidden-door"],
+      "updated_scene_ids": ["alpha"],
+      "unchanged_scene_ids": ["beta"],
+      "removed_scene_ids": []
+    }
+  ],
+  "scenes": {
+    "hidden-door": { "description": "A secret door swings open…" }
+  }
+}
+```
+
+**Errors**
+
+- `404 Not Found` – Branch identifier does not exist on disk.
+
+### `DELETE /scenes/branches/{branch_id}`
+
+Remove a saved branch definition once it has been merged, superseded, or deemed
+obsolete. The API deletes the underlying JSON snapshot and returns an empty
+response body.
+
+**Path parameters**
+
+- `branch_id` – Identifier returned when the branch was created.
+
+**Response – 204 No Content**
+
+**Errors**
+
+- `404 Not Found` – Branch identifier does not exist on disk.
+
 ### `POST /scenes/branches`
 
 Persist a branch definition so it can be revisited later or imported into a

--- a/src/fastapi/app.py
+++ b/src/fastapi/app.py
@@ -86,6 +86,27 @@ class FastAPI:
 
         return decorator
 
+    def delete(
+        self,
+        path: str,
+        response_model: Any | None = None,
+        *,
+        status_code: int | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register a handler for ``DELETE`` requests."""
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self._routes[("DELETE", path)] = _Route(
+                method="DELETE",
+                path=path,
+                endpoint=func,
+                response_model=response_model,
+                status_code=status_code,
+            )
+            return func
+
+        return decorator
+
     def _resolve_route(self, method: str, path: str) -> tuple[_Route, dict[str, str]]:
         key = (method, path)
         if key in self._routes:

--- a/src/fastapi/testclient.py
+++ b/src/fastapi/testclient.py
@@ -57,6 +57,15 @@ class TestClient:
         payload, text = _serialise(result)
         return _Response(status, payload, text)
 
+    def delete(self, path: str, params: Mapping[str, Any] | None = None) -> _Response:
+        try:
+            result, status = self._app._dispatch("DELETE", path, params or {})
+        except HTTPException as exc:
+            return _Response(exc.status_code, {"detail": exc.detail})
+
+        payload, text = _serialise(result)
+        return _Response(status, payload, text)
+
 
 def _serialise(value: Any) -> tuple[Any, str | None]:
     if hasattr(value, "body"):


### PR DESCRIPTION
## Summary
- extend the scene branch store/service with helpers to load and delete saved branch definitions
- expose GET and DELETE `/api/scenes/branches/{branch_id}` endpoints and document the workflows
- update the FastAPI shim and regression suite to cover the new behaviour

## Testing
- black src/textadventure/api/app.py tests/test_api_scenes.py
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1c00f591483249060ddc28929468e