### PR TITLE
Add Docker container for running the API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.venv/
+.git/
+.github/
+docs/
+tests/
+*.log
+*.sqlite3
+*.db
+Dockerfile
+TASKS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install runtime dependencies.
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY src ./src
+
+ENV PORT=8000
+
+EXPOSE 8000
+
+CMD [ \
+    "uvicorn", \
+    "textadventure.api.app:create_app", \
+    "--factory", \
+    "--host", "0.0.0.0", \
+    "--port", "8000" \
+]

--- a/README.md
+++ b/README.md
@@ -196,6 +196,21 @@ black src tests    # code formatting
 ruff src tests     # linting
 ```
 
+### Running the API in Docker
+
+Build and run the FastAPI service inside a container to expose the authoring
+and analytics endpoints without installing the Python toolchain locally:
+
+```bash
+docker build -t textadventure-api .
+docker run --rm -p 8000:8000 textadventure-api
+```
+
+The image installs all runtime dependencies and launches Uvicorn with
+`textadventure.api.app:create_app`. Once the container is running, visit
+`http://localhost:8000/docs` to explore the automatically generated OpenAPI UI
+or hit `/api/scenes` to fetch the bundled demo scenes.
+
 ## Contributing
 
 Read the detailed contributor guidelines in

--- a/TASKS.md
+++ b/TASKS.md
@@ -363,7 +363,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] CLI command to launch editor
       - [ ] Development mode integration
     - [ ] Create deployment pipeline:
-      - [ ] Docker containerization
+      - [x] Docker containerization *(Added a Dockerfile and README instructions for running the API via Uvicorn in a container.)*
       - [ ] Environment configuration
       - [ ] Production build optimization
       - [ ] Static asset management

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ openai>=1.0.0
 python-dotenv>=1.0
 mypy>=1.5.1
 fastapi>=0.110
+uvicorn[standard]>=0.24


### PR DESCRIPTION
## Summary
- add a Dockerfile and .dockerignore to package the FastAPI scene API with Uvicorn
- document how to build and run the containerised service in the README
- add the Uvicorn dependency and mark the Docker containerisation task complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1d73965608324a6b5d06bc4ebb360