### PR TITLE
Add FastAPI project registry endpoints

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -314,7 +314,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Support deleting saved branch definitions via the API with filesystem persistence cleanup.
         - [x] Document the retrieval and deletion workflows and add regression tests.
     - [ ] Create project management features:
-      - [ ] Multiple adventure projects
+    - [ ] Multiple adventure projects
+      - [x] Add a filesystem-backed project registry for discovering available adventure datasets.
+      - [x] Expose API endpoints for listing and retrieving registered projects.
+      - [x] Document the project workflow and cover it with automated tests.
       - [ ] Project templates
       - [ ] Asset organization
       - [ ] Collaborative permissions

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -87,15 +87,19 @@ services.
   bundled scene data and analytics. `SceneService` returns paginated summaries with
   validation metadata, produces Git-style diffs for uploaded datasets, `SceneSearchResponse`
   powers full-text queries, and helper parsers validate query parameters for
-  field-type and validation filters.
+  field-type and validation filters. The API also exposes project-management
+  endpoints backed by `ProjectService`, allowing tooling to discover registered
+  adventure datasets and retrieve their scene payloads alongside checksum and
+  version metadata.
 - **Pydantic response models** – `SceneSummary`, `SceneSearchResultResource`, and
   supporting models normalise the API payloads consumed by prospective web tools or
   external services.
 - **Deployment settings (`textadventure.api.settings.SceneApiSettings`)** – Reads
   environment variables such as `TEXTADVENTURE_SCENE_PATH`,
-  `TEXTADVENTURE_SCENE_PACKAGE`, `TEXTADVENTURE_SCENE_RESOURCE`, and
-  `TEXTADVENTURE_BRANCH_ROOT` so the API can target custom scene datasets and
-  branch storage directories without code changes.
+  `TEXTADVENTURE_SCENE_PACKAGE`, `TEXTADVENTURE_SCENE_RESOURCE`,
+  `TEXTADVENTURE_BRANCH_ROOT`, and `TEXTADVENTURE_PROJECT_ROOT` so the API can
+  target custom scene datasets, branch storage directories, and an optional
+  project registry without code changes.
 
 Use this reference alongside the architecture overview to dive deeper into specific
 modules when extending the engine or integrating new agent capabilities.

--- a/src/textadventure/api/settings.py
+++ b/src/textadventure/api/settings.py
@@ -40,6 +40,7 @@ class SceneApiSettings:
     scene_resource_name: str = "scripted_scenes.json"
     scene_path: Path | None = None
     branch_root: Path | None = None
+    project_root: Path | None = None
 
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> "SceneApiSettings":
@@ -62,12 +63,14 @@ class SceneApiSettings:
         )
         scene_path = _normalise_path(source.get("TEXTADVENTURE_SCENE_PATH"))
         branch_root = _normalise_path(source.get("TEXTADVENTURE_BRANCH_ROOT"))
+        project_root = _normalise_path(source.get("TEXTADVENTURE_PROJECT_ROOT"))
 
         return cls(
             scene_package=scene_package,
             scene_resource_name=scene_resource,
             scene_path=scene_path,
             branch_root=branch_root,
+            project_root=project_root,
         )
 
 


### PR DESCRIPTION
## Summary
- add a filesystem-backed project registry and supporting service objects for adventure datasets
- expose `/api/projects` endpoints with optional configuration via `SceneApiSettings`
- document the project workflow and cover it with new API regression tests

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1e21df5c48324a17e49fd559c5c2d