### PR TITLE
Add project template management endpoints

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -316,11 +316,11 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
     - [ ] Create project management features:
     - [ ] Multiple adventure projects
       - [x] Add a filesystem-backed project registry for discovering available adventure datasets.
-      - [x] Expose API endpoints for listing and retrieving registered projects.
-      - [x] Document the project workflow and cover it with automated tests.
-      - [ ] Project templates
-      - [ ] Asset organization
-      - [ ] Collaborative permissions
+    - [x] Expose API endpoints for listing and retrieving registered projects.
+    - [x] Document the project workflow and cover it with automated tests.
+    - [x] Project templates *(Added template catalogue/listing endpoints plus an instantiation workflow that materialises new projects from reusable datasets, with documentation and regression tests.)*
+    - [ ] Asset organization
+    - [ ] Collaborative permissions
 
   - [ ] **Phase 8: Quality of Life & Polish**
     - [ ] Implement comprehensive search:

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -90,16 +90,19 @@ services.
   field-type and validation filters. The API also exposes project-management
   endpoints backed by `ProjectService`, allowing tooling to discover registered
   adventure datasets and retrieve their scene payloads alongside checksum and
-  version metadata.
+  version metadata. `ProjectTemplateService` lists reusable project templates and
+  provides an instantiation endpoint that materialises a new project directory by
+  copying the template scenes and metadata.
 - **Pydantic response models** – `SceneSummary`, `SceneSearchResultResource`, and
   supporting models normalise the API payloads consumed by prospective web tools or
   external services.
 - **Deployment settings (`textadventure.api.settings.SceneApiSettings`)** – Reads
   environment variables such as `TEXTADVENTURE_SCENE_PATH`,
   `TEXTADVENTURE_SCENE_PACKAGE`, `TEXTADVENTURE_SCENE_RESOURCE`,
-  `TEXTADVENTURE_BRANCH_ROOT`, and `TEXTADVENTURE_PROJECT_ROOT` so the API can
-  target custom scene datasets, branch storage directories, and an optional
-  project registry without code changes.
+  `TEXTADVENTURE_BRANCH_ROOT`, `TEXTADVENTURE_PROJECT_ROOT`, and
+  `TEXTADVENTURE_PROJECT_TEMPLATE_ROOT` so the API can target custom scene
+  datasets, branch storage directories, a project registry, and an optional
+  template catalogue without code changes.
 
 Use this reference alongside the architecture overview to dive deeper into specific
 modules when extending the engine or integrating new agent capabilities.

--- a/src/textadventure/api/settings.py
+++ b/src/textadventure/api/settings.py
@@ -41,6 +41,7 @@ class SceneApiSettings:
     scene_path: Path | None = None
     branch_root: Path | None = None
     project_root: Path | None = None
+    project_template_root: Path | None = None
 
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> "SceneApiSettings":
@@ -64,6 +65,9 @@ class SceneApiSettings:
         scene_path = _normalise_path(source.get("TEXTADVENTURE_SCENE_PATH"))
         branch_root = _normalise_path(source.get("TEXTADVENTURE_BRANCH_ROOT"))
         project_root = _normalise_path(source.get("TEXTADVENTURE_PROJECT_ROOT"))
+        project_template_root = _normalise_path(
+            source.get("TEXTADVENTURE_PROJECT_TEMPLATE_ROOT")
+        )
 
         return cls(
             scene_package=scene_package,
@@ -71,6 +75,7 @@ class SceneApiSettings:
             scene_path=scene_path,
             branch_root=branch_root,
             project_root=project_root,
+            project_template_root=project_template_root,
         )
 
 

--- a/tests/test_api_scenes.py
+++ b/tests/test_api_scenes.py
@@ -1630,11 +1630,14 @@ def test_scene_repository_loads_from_configured_path(tmp_path: Path) -> None:
 def test_scene_api_settings_from_env(monkeypatch: Any, tmp_path: Path) -> None:
     data_path = tmp_path / "dataset.json"
     branch_root = tmp_path / "branches"
+    template_root = tmp_path / "templates"
 
     monkeypatch.setenv("TEXTADVENTURE_SCENE_PACKAGE", "my.package")
     monkeypatch.setenv("TEXTADVENTURE_SCENE_RESOURCE", "dataset.json")
     monkeypatch.setenv("TEXTADVENTURE_SCENE_PATH", str(data_path))
     monkeypatch.setenv("TEXTADVENTURE_BRANCH_ROOT", str(branch_root))
+    monkeypatch.setenv("TEXTADVENTURE_PROJECT_ROOT", str(tmp_path / "projects"))
+    monkeypatch.setenv("TEXTADVENTURE_PROJECT_TEMPLATE_ROOT", str(template_root))
 
     settings = SceneApiSettings.from_env()
 
@@ -1642,6 +1645,8 @@ def test_scene_api_settings_from_env(monkeypatch: Any, tmp_path: Path) -> None:
     assert settings.scene_resource_name == "dataset.json"
     assert settings.scene_path == data_path
     assert settings.branch_root == branch_root
+    assert settings.project_root == tmp_path / "projects"
+    assert settings.project_template_root == template_root
 
 
 def test_scene_api_settings_ignore_blank_values(monkeypatch: Any) -> None:
@@ -1649,6 +1654,8 @@ def test_scene_api_settings_ignore_blank_values(monkeypatch: Any) -> None:
     monkeypatch.setenv("TEXTADVENTURE_SCENE_RESOURCE", "   ")
     monkeypatch.setenv("TEXTADVENTURE_SCENE_PATH", "   ")
     monkeypatch.setenv("TEXTADVENTURE_BRANCH_ROOT", "")
+    monkeypatch.setenv("TEXTADVENTURE_PROJECT_ROOT", "   ")
+    monkeypatch.setenv("TEXTADVENTURE_PROJECT_TEMPLATE_ROOT", "")
 
     settings = SceneApiSettings.from_env()
 
@@ -1656,6 +1663,8 @@ def test_scene_api_settings_ignore_blank_values(monkeypatch: Any) -> None:
     assert settings.scene_resource_name == "scripted_scenes.json"
     assert settings.scene_path is None
     assert settings.branch_root is None
+    assert settings.project_root is None
+    assert settings.project_template_root is None
 
 
 def test_create_app_uses_environment_scene_path(


### PR DESCRIPTION
## Summary
- add project template resources, filesystem creation helpers, and API endpoints for listing and instantiating adventure templates
- extend SceneApiSettings with template root configuration and validation utilities for project creation
- document the template workflow and cover it with new FastAPI integration tests

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1fd5fb21483248ae73f258cd189a7