### PR TITLE
Implement scene update endpoint with optimistic concurrency

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -146,7 +146,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
     - [ ] Implement FastAPI backend with the following endpoints:
       - [x] `GET /api/scenes` - List all scenes with metadata *(Implemented read-only endpoint backed by the scripted scene store, including pagination, filtering, and validation summaries.)*
       - [x] `GET /api/scenes/{scene_id}` - Get detailed scene data *(Implemented read-only detail endpoint returning full scene definitions with optional validation metadata.)*
-      - [ ] `PUT /api/scenes/{scene_id}` - Update existing scene
+      - [x] `PUT /api/scenes/{scene_id}` - Update existing scene *(Adds optimistic concurrency checks, persistence, and regression tests.)*
       - [ ] `POST /api/scenes` - Create new scene
       - [ ] `DELETE /api/scenes/{scene_id}` - Delete scene (with dependency checks)
       - [x] `GET /api/scenes/validate` - Full integrity validation *(Added read-only endpoint returning quality, reachability, and item-flow summaries with test coverage.)*

--- a/src/fastapi/app.py
+++ b/src/fastapi/app.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel
 class HTTPException(Exception):
     """Exception mirroring FastAPI's HTTPException signature."""
 
-    def __init__(self, status_code: int, detail: str | None = None) -> None:
+    def __init__(self, status_code: int, detail: Any | None = None) -> None:
         super().__init__(detail)
         self.status_code = status_code
         self.detail = detail
@@ -77,6 +77,27 @@ class FastAPI:
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             self._routes[("POST", path)] = _Route(
                 method="POST",
+                path=path,
+                endpoint=func,
+                response_model=response_model,
+                status_code=status_code,
+            )
+            return func
+
+        return decorator
+
+    def put(
+        self,
+        path: str,
+        response_model: Any | None = None,
+        *,
+        status_code: int | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register a handler for ``PUT`` requests."""
+
+        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+            self._routes[("PUT", path)] = _Route(
+                method="PUT",
                 path=path,
                 endpoint=func,
                 response_model=response_model,

--- a/src/fastapi/testclient.py
+++ b/src/fastapi/testclient.py
@@ -57,6 +57,20 @@ class TestClient:
         payload, text = _serialise(result)
         return _Response(status, payload, text)
 
+    def put(
+        self,
+        path: str,
+        params: Mapping[str, Any] | None = None,
+        json: Any | None = None,
+    ) -> _Response:
+        try:
+            result, status = self._app._dispatch("PUT", path, params or {}, json)
+        except HTTPException as exc:
+            return _Response(exc.status_code, {"detail": exc.detail})
+
+        payload, text = _serialise(result)
+        return _Response(status, payload, text)
+
     def delete(self, path: str, params: Mapping[str, Any] | None = None) -> _Response:
         try:
             result, status = self._app._dispatch("DELETE", path, params or {})


### PR DESCRIPTION
## Summary
- add persistence support and version conflict handling to update individual scenes
- expose a PUT /api/scenes/{scene_id} endpoint that returns mutation metadata
- teach the FastAPI test harness about PUT requests and cover update flows with new tests
- mark the associated API task complete in the backlog

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e220d44bf8832494b6816760f26e81