### PR TITLE
Add project asset inventory endpoint

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -319,7 +319,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
     - [x] Expose API endpoints for listing and retrieving registered projects.
     - [x] Document the project workflow and cover it with automated tests.
     - [x] Project templates *(Added template catalogue/listing endpoints plus an instantiation workflow that materialises new projects from reusable datasets, with documentation and regression tests.)*
-    - [ ] Asset organization
+    - [x] Asset organization
+      - [x] Add an asset inventory endpoint that enumerates project directories and files with MIME hints and timestamps.
+      - [x] Ensure new projects ship with a prepared `assets/` directory and cover the flow with automated tests.
+      - [x] Document the asset listing API and response schema for editor tooling.
     - [ ] Collaborative permissions
 
   - [ ] **Phase 8: Quality of Life & Polish**

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -89,13 +89,16 @@ services.
   powers full-text queries, and helper parsers validate query parameters for
   field-type and validation filters. The API also exposes project-management
   endpoints backed by `ProjectService`, allowing tooling to discover registered
-  adventure datasets and retrieve their scene payloads alongside checksum and
-  version metadata. `ProjectTemplateService` lists reusable project templates and
-  provides an instantiation endpoint that materialises a new project directory by
-  copying the template scenes and metadata.
+  adventure datasets, retrieve their scene payloads alongside checksum and
+  version metadata, and enumerate project assets through structured listings.
+  `ProjectTemplateService` lists reusable project templates and provides an
+  instantiation endpoint that materialises a new project directory by copying the
+  template scenes and metadata.
 - **Pydantic response models** – `SceneSummary`, `SceneSearchResultResource`, and
   supporting models normalise the API payloads consumed by prospective web tools or
-  external services.
+  external services. Recent additions include `ProjectAssetResource` and
+  `ProjectAssetListResponse`, which document the assets bundled with a project so
+  editors can surface file metadata, MIME types, and modification timestamps.
 - **Deployment settings (`textadventure.api.settings.SceneApiSettings`)** – Reads
   environment variables such as `TEXTADVENTURE_SCENE_PATH`,
   `TEXTADVENTURE_SCENE_PACKAGE`, `TEXTADVENTURE_SCENE_RESOURCE`,

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -858,6 +858,123 @@ alongside the persisted timestamps:
 Clients treat warnings as advisory but block saves when any `severity="error"`
 issue appears.
 
+## Project management endpoints
+
+Projects bundle scene datasets together with metadata so that tooling can
+discover available adventures without parsing every JSON file. The API exposes
+lightweight read operations for listing registered projects, retrieving a
+project's dataset, and enumerating bundled assets for use in editors or runtime
+packaging.
+
+### `GET /projects`
+
+Return the registered projects under the configured project root. Entries expose
+metadata derived from the dataset timestamp and checksum so clients can surface
+version information in dashboards.
+
+**Response – 200 OK**
+
+```json
+{
+  "data": [
+    {
+      "id": "atlas",
+      "name": "Atlas",
+      "description": "Short demo adventure.",
+      "scene_count": 12,
+      "created_at": "2024-05-01T10:00:00Z",
+      "updated_at": "2024-05-01T10:00:00Z",
+      "version_id": "20240501T100000Z-9a1b2c3d",
+      "checksum": "d68f…"
+    }
+  ]
+}
+```
+
+### `GET /projects/{project_id}`
+
+Fetch the full scene dataset for a specific project. Useful when initialising an
+editor workspace or downloading a dataset for offline review.
+
+**Path parameters**
+
+- `project_id` – Identifier returned by `GET /projects`.
+
+**Response – 200 OK**
+
+```json
+{
+  "data": {
+    "id": "atlas",
+    "name": "Atlas",
+    "description": "Short demo adventure.",
+    "scene_count": 12,
+    "created_at": "2024-05-01T10:00:00Z",
+    "updated_at": "2024-05-01T10:00:00Z",
+    "version_id": "20240501T100000Z-9a1b2c3d",
+    "checksum": "d68f…"
+  },
+  "scenes": {
+    "start": {
+      "description": "The adventure begins…"
+    }
+  }
+}
+```
+
+### `GET /projects/{project_id}/assets`
+
+Enumerate static assets stored alongside a project. Responses list directories
+and files relative to the project's `assets/` folder, including MIME type hints,
+file sizes, and modification timestamps so editors can preview and manage
+supporting media.
+
+**Path parameters**
+
+- `project_id` – Identifier returned by `GET /projects`.
+
+**Response – 200 OK**
+
+```json
+{
+  "project_id": "atlas",
+  "root": "assets",
+  "generated_at": "2024-05-04T15:00:00Z",
+  "assets": [
+    {
+      "path": "images",
+      "name": "images",
+      "type": "directory",
+      "size": null,
+      "content_type": null,
+      "updated_at": "2024-05-02T09:00:00Z"
+    },
+    {
+      "path": "notes.txt",
+      "name": "notes.txt",
+      "type": "file",
+      "size": 28,
+      "content_type": "text/plain",
+      "updated_at": "2024-05-04T15:00:00Z"
+    },
+    {
+      "path": "images/logo.png",
+      "name": "logo.png",
+      "type": "file",
+      "size": 4,
+      "content_type": "image/png",
+      "updated_at": "2024-05-03T12:00:00Z"
+    }
+  ]
+}
+```
+
+**Errors**
+
+- `404 Not Found` – Project identifier does not exist or project support is
+  disabled.
+- `400 Bad Request` – Project assets directory exists but is not a directory.
+
 ## Notes for Future Iterations
 
 - Introduce `PATCH /scenes/{scene_id}` for partial updates once concurrent edit


### PR DESCRIPTION
## Summary
- add a project asset listing endpoint that surfaces file metadata for editor tooling
- ensure new projects create an `assets/` directory and cover the listing flow with tests
- document the asset API and update the backlog to reflect the completed work

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e23636e6b4832487c1bda5739688bd