### PR TITLE
Add collaborator management endpoints to project API

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -323,7 +323,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [x] Add an asset inventory endpoint that enumerates project directories and files with MIME hints and timestamps.
       - [x] Ensure new projects ship with a prepared `assets/` directory and cover the flow with automated tests.
       - [x] Document the asset listing API and response schema for editor tooling.
-    - [ ] Collaborative permissions
+    - [x] Collaborative permissions
+      - [x] Define collaborator roles and metadata persistence.
+      - [x] Add API endpoints for managing project collaborators.
+      - [x] Cover collaborator workflows with automated tests.
 
   - [ ] **Phase 8: Quality of Life & Polish**
     - [ ] Implement comprehensive search:


### PR DESCRIPTION
## Summary
- add collaborator roles and metadata persistence so project resources expose collaborator counts and stored collaborator lists
- provide GET/PUT endpoints on projects for listing and replacing collaborator rosters with validation
- extend the project API tests to cover collaborator flows and ensure counts are reflected in existing responses

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e239bb9b6c83248ace48adb5df34ce