### PR TITLE
Add CLI command for launching editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ integration.
   small playable loop.
 - **Guided onboarding** – Enter `tutorial` inside the CLI to walk through the
   core commands, persistence options, and debugging tools at your own pace.
+- **In-CLI editor launcher** – Type `editor` to start or stop the scene editor
+  API server without leaving the adventure loop.
 - **Rich world modelling** – `WorldState` tracks locations, actors, inventory,
   remembered observations, and player actions.
 - **Story engines** – the `StoryEngine` protocol defines how narrative beats
@@ -72,16 +74,19 @@ TASKS.md                   # Planning notes and backlog ideas
    ```bash
    python src/main.py
  ```
-  Run `python src/main.py --help` to discover options for enabling persistence
+ Run `python src/main.py --help` to discover options for enabling persistence
   (`--session-dir`, `--session-id`, `--no-persistence`) and transcript logging
-  (`--log-file`). The CLI can also attach an LLM-backed secondary narrator via
-  `--llm-provider`, forwarding additional key/value pairs to the selected
+  (`--log-file`). Configure the embedded editor command with
+  `--editor-host`/`--editor-port`, or disable it entirely with `--no-editor`
+  when you do not need the API. The CLI can also attach an LLM-backed secondary
+  narrator via `--llm-provider`, forwarding additional key/value pairs to the selected
   provider with repeated `--llm-option` flags (for example,
   `--llm-provider openai --llm-option api_key=...`). Alternatively pass
   `--llm-config path/to/config.json` to load the provider identifier and
   options from a JSON file. Once the adventure starts, type `help` for a
-  summary of system commands or `tutorial` to follow an interactive walkthrough
-  covering choices, status, saving, and quitting. A more detailed walkthrough
+  summary of system commands, `tutorial` for an interactive walkthrough,
+  and `editor` to start or stop the scene editor API without leaving the
+  adventure. A more detailed walkthrough
   covering environment
   setup, optional features, and troubleshooting lives in
   [`docs/getting_started.md`](docs/getting_started.md).

--- a/TASKS.md
+++ b/TASKS.md
@@ -369,7 +369,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
   - [ ] **Phase 9: Integration & Deployment**
     - [ ] Integrate editor with existing CLI workflow:
       - [ ] File watching for automatic reloads
-      - [ ] CLI command to launch editor
+      - [x] CLI command to launch editor *(Added in-CLI `editor` command with lifecycle controls, host/port configuration flags, and documentation.)*
       - [ ] Development mode integration
     - [ ] Create deployment pipeline:
       - [x] Docker containerization *(Added a Dockerfile and README instructions for running the API via Uvicorn in a container.)*

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,7 @@ Launch the scripted text adventure from the repository root:
 python src/main.py
 ```
 
-The CLI will print the current scene narration, available choices, and a prompt for your next command. Enter `help` to see built-in commands such as `save`, `load`, `status`, and `quit`, or type `tutorial` for an interactive walkthrough of the same features.
+The CLI will print the current scene narration, available choices, and a prompt for your next command. Enter `help` to see built-in commands such as `save`, `load`, `status`, `editor`, and `quit`, or type `tutorial` for an interactive walkthrough of the same features.
 
 ### Enable Persistence and Logging
 
@@ -63,6 +63,18 @@ python src/main.py \
 - `--session-dir` sets the directory where save files are stored (it will be created if it does not exist).
 - `--session-id` controls the save-file prefix so multiple runs can coexist.
 - `--log-file` writes a structured transcript containing narration, player input, and agent metadata.
+
+### Launch the Scene Editor API
+
+Type `editor` inside the CLI to start the FastAPI application that powers the web-based scene editor. The command reports the local URL and supports `editor stop`/`editor status` for lifecycle control. Configure the binding with the following command-line flags when starting the CLI:
+
+```bash
+python src/main.py --editor-host 0.0.0.0 --editor-port 9000
+```
+
+- `--editor-host` selects the network interface exposed by the editor API (defaults to `127.0.0.1`).
+- `--editor-port` chooses the listening port (defaults to `8000`).
+- `--no-editor` disables the `editor` command entirely for environments where launching subprocesses is undesirable.
 
 ### Add an LLM Co-narrator
 


### PR DESCRIPTION
## Summary
- add an `EditorLauncher` helper and expose a new `editor` command in the CLI with host/port configuration flags
- update documentation and the backlog to describe the editor launcher workflow
- cover the new command with unit tests exercising launcher control and disabled scenarios

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e24c0a766c8324ab340ee3b7ed0a26