### PR TITLE
Add automatic scene backups and configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ where scene data and branch definitions are loaded from:
 - ``TEXTADVENTURE_BRANCH_ROOT`` – Directory where saved branch definitions and
   plans are stored. Defaults to ``./scene_branches`` relative to the current
   working directory.
+- ``TEXTADVENTURE_AUTOMATIC_BACKUP_DIR`` – Directory where automatic backups
+  are written before scene datasets are mutated. Leave unset to disable
+  automatic backups.
+- ``TEXTADVENTURE_AUTOMATIC_BACKUP_RETENTION`` – Optional positive integer
+  limiting how many automatic backups are kept. When unset all automatic
+  backups are retained.
 
 All values accept ``~`` prefixes, making it easy to redirect the service towards
 shared datasets or persistent storage locations.

--- a/TASKS.md
+++ b/TASKS.md
@@ -382,7 +382,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Collaborative editing features
       - [ ] Access control
     - [ ] Implement backup and recovery:
-      - [ ] Automatic backups
+      - [x] Automatic backups
+        - [x] Add configurable automatic backup directory and retention settings.
+        - [x] Persist pre-mutation automatic backups with regression tests.
+        - [x] Document the automatic backup workflow and settings for operators.
       - [ ] Cloud storage integration
       - [ ] Disaster recovery procedures
       - [ ] Data export for migration

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -102,10 +102,11 @@ services.
 - **Deployment settings (`textadventure.api.settings.SceneApiSettings`)** – Reads
   environment variables such as `TEXTADVENTURE_SCENE_PATH`,
   `TEXTADVENTURE_SCENE_PACKAGE`, `TEXTADVENTURE_SCENE_RESOURCE`,
-  `TEXTADVENTURE_BRANCH_ROOT`, `TEXTADVENTURE_PROJECT_ROOT`, and
+  `TEXTADVENTURE_BRANCH_ROOT`, `TEXTADVENTURE_AUTOMATIC_BACKUP_DIR`,
+  `TEXTADVENTURE_AUTOMATIC_BACKUP_RETENTION`, `TEXTADVENTURE_PROJECT_ROOT`, and
   `TEXTADVENTURE_PROJECT_TEMPLATE_ROOT` so the API can target custom scene
-  datasets, branch storage directories, a project registry, and an optional
-  template catalogue without code changes.
+  datasets, branch storage directories, automatic backup locations, a project
+  registry, and an optional template catalogue without code changes.
 
 Use this reference alongside the architecture overview to dive deeper into specific
 modules when extending the engine or integrating new agent capabilities.

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -332,6 +332,13 @@ minified JSON depending on the ``export_format`` argument and returns metadata
 about the saved snapshot (version id, checksum, and timestamp) so operators can
 log or display confirmation to authors.
 
+Deployments can also configure `SceneService` to create these backups
+automatically before mutating scene data. Setting
+``TEXTADVENTURE_AUTOMATIC_BACKUP_DIR`` directs the API to snapshot the current
+dataset ahead of operations such as ``PUT /api/scenes/{scene_id}``, while
+``TEXTADVENTURE_AUTOMATIC_BACKUP_RETENTION`` limits how many automatic backups
+are kept on disk after each write.
+
 
 ### `POST /scenes/diff`
 

--- a/src/textadventure/api/settings.py
+++ b/src/textadventure/api/settings.py
@@ -42,6 +42,8 @@ class SceneApiSettings:
     branch_root: Path | None = None
     project_root: Path | None = None
     project_template_root: Path | None = None
+    automatic_backup_dir: Path | None = None
+    automatic_backup_retention: int | None = None
 
     @classmethod
     def from_env(cls, environ: Mapping[str, str] | None = None) -> "SceneApiSettings":
@@ -68,6 +70,26 @@ class SceneApiSettings:
         project_template_root = _normalise_path(
             source.get("TEXTADVENTURE_PROJECT_TEMPLATE_ROOT")
         )
+        automatic_backup_dir = _normalise_path(
+            source.get("TEXTADVENTURE_AUTOMATIC_BACKUP_DIR")
+        )
+
+        automatic_backup_retention: int | None = None
+        retention_raw = source.get("TEXTADVENTURE_AUTOMATIC_BACKUP_RETENTION")
+        if retention_raw is not None:
+            trimmed_retention = retention_raw.strip()
+            if trimmed_retention:
+                try:
+                    parsed_retention = int(trimmed_retention)
+                except ValueError as exc:
+                    raise ValueError(
+                        "TEXTADVENTURE_AUTOMATIC_BACKUP_RETENTION must be a positive integer."
+                    ) from exc
+                if parsed_retention < 1:
+                    raise ValueError(
+                        "TEXTADVENTURE_AUTOMATIC_BACKUP_RETENTION must be greater than zero."
+                    )
+                automatic_backup_retention = parsed_retention
 
         return cls(
             scene_package=scene_package,
@@ -76,6 +98,8 @@ class SceneApiSettings:
             branch_root=branch_root,
             project_root=project_root,
             project_template_root=project_template_root,
+            automatic_backup_dir=automatic_backup_dir,
+            automatic_backup_retention=automatic_backup_retention,
         )
 
 


### PR DESCRIPTION
## Summary
- add automatic backup support to `SceneService`, including retention pruning and integration with `create_app`
- expose new environment variables for automatic backups via `SceneApiSettings` and document them in the README and API docs
- cover automatic backup flows and settings parsing with new pytest scenarios and update the project task list

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e25df3aafc83248cbf350b3aa10b74