### PR TITLE
Add CLI scene dataset watcher with automatic reloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,15 @@ TASKS.md                   # Planning notes and backlog ideas
    ```bash
    python src/main.py
  ```
- Run `python src/main.py --help` to discover options for enabling persistence
-  (`--session-dir`, `--session-id`, `--no-persistence`) and transcript logging
-  (`--log-file`). Configure the embedded editor command with
-  `--editor-host`/`--editor-port`, or disable it entirely with `--no-editor`
-  when you do not need the API. The CLI can also attach an LLM-backed secondary
-  narrator via `--llm-provider`, forwarding additional key/value pairs to the selected
+Run `python src/main.py --help` to discover options for enabling persistence
+ (`--session-dir`, `--session-id`, `--no-persistence`) and transcript logging
+ (`--log-file`). Use `--scene-path` (or the `TEXTADVENTURE_SCENE_PATH`
+ environment variable) to load scenes from an external JSON file. When
+ configured the CLI watches the file for changes and reloads the story between
+ turns, making it easy to iterate alongside the editor API. Configure the
+ embedded editor command with `--editor-host`/`--editor-port`, or disable it
+ entirely with `--no-editor` when you do not need the API. The CLI can also
+ attach an LLM-backed secondary narrator via `--llm-provider`, forwarding additional key/value pairs to the selected
   provider with repeated `--llm-option` flags (for example,
   `--llm-provider openai --llm-option api_key=...`). Alternatively pass
   `--llm-config path/to/config.json` to load the provider identifier and

--- a/TASKS.md
+++ b/TASKS.md
@@ -368,7 +368,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
 
   - [ ] **Phase 9: Integration & Deployment**
     - [ ] Integrate editor with existing CLI workflow:
-      - [ ] File watching for automatic reloads
+      - [x] File watching for automatic reloads *(CLI can now load external scene files, watch them for changes, and ships with documentation plus regression tests.)*
+        - [x] Allow the CLI to load scripted scenes from an external JSON file so it shares data with the editor API.
+        - [x] Implement a lightweight watcher that detects changes to the external scene file and reloads the scripted story engine in-place.
+        - [x] Document the workflow and add automated coverage for the reload behaviour.
       - [x] CLI command to launch editor *(Added in-CLI `editor` command with lifecycle controls, host/port configuration flags, and documentation.)*
       - [ ] Development mode integration
     - [ ] Create deployment pipeline:

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -76,6 +76,12 @@ python src/main.py --editor-host 0.0.0.0 --editor-port 9000
 - `--editor-port` chooses the listening port (defaults to `8000`).
 - `--no-editor` disables the `editor` command entirely for environments where launching subprocesses is undesirable.
 
+When you want to iterate on the scripted scenes alongside the editor, start the
+CLI with `--scene-path path/to/scenes.json` (or set
+`TEXTADVENTURE_SCENE_PATH`). The adventure will load data from that file and
+watch it for changes between turns, so edits in the web UI or another editor
+appear immediately without restarting the session.
+
 ### Add an LLM Co-narrator
 
 To experiment with hybrid scripted + LLM storytelling, register an LLM provider via the registry flags:

--- a/src/textadventure/scripted_story_engine.py
+++ b/src/textadventure/scripted_story_engine.py
@@ -435,6 +435,11 @@ class ScriptedStoryEngine(StoryEngine):
 
         return MappingProxyType(self._scenes)
 
+    def replace_scenes(self, scenes: Mapping[str, _Scene]) -> None:
+        """Replace the configured scenes with a new mapping."""
+
+        self._scenes = scenes
+
     def propose_event(
         self,
         world_state: WorldState,


### PR DESCRIPTION
## Summary
- allow the CLI to load scripted scenes from an external JSON file via `--scene-path` or `TEXTADVENTURE_SCENE_PATH`
- add a scene dataset monitor that reloads the scripted engine when the file changes and surfaces status messages to the player
- document the workflow and add regression tests covering reloads and error handling

## Testing
- black tests/test_cli.py
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e673611083248a808b13487b52fe