### PR TITLE
Add API endpoint for downloading project assets

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -381,6 +381,8 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [x] Environment configuration *(API now honours environment variables for scene datasets and branch storage with docs and automated tests.)*
       - [ ] Production build optimization
       - [ ] Static asset management
+        - [x] Expose API endpoint to download project asset files for editors.
+        - [ ] Provide asset upload and deletion endpoints.
     - [ ] Add authentication and user management:
       - [ ] User accounts and profiles
       - [ ] Project sharing and permissions

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -90,7 +90,9 @@ services.
   field-type and validation filters. The API also exposes project-management
   endpoints backed by `ProjectService`, allowing tooling to discover registered
   adventure datasets, retrieve their scene payloads alongside checksum and
-  version metadata, and enumerate project assets through structured listings.
+  version metadata, enumerate project assets through structured listings, and
+  download individual asset files with appropriate content headers for editor
+  previews.
   `ProjectTemplateService` lists reusable project templates and provides an
   instantiation endpoint that materialises a new project directory by copying the
   template scenes and metadata.

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -982,6 +982,26 @@ supporting media.
   disabled.
 - `400 Bad Request` – Project assets directory exists but is not a directory.
 
+### `GET /projects/{project_id}/assets/{path}`
+
+Download an individual asset stored in the project's `assets/` directory. The
+endpoint streams binary content with a best-effort `Content-Type` header and a
+download-friendly `Content-Disposition` filename.
+
+**Path parameters**
+
+- `project_id` – Identifier returned by `GET /projects`.
+- `path` – Relative path to the asset beneath the `assets/` directory.
+
+**Response – 200 OK**
+
+Binary response body containing the file contents.
+
+**Errors**
+
+- `404 Not Found` – Project or asset does not exist.
+- `400 Bad Request` – Asset path is invalid or targets a directory.
+
 ## Notes for Future Iterations
 
 - Introduce `PATCH /scenes/{scene_id}` for partial updates once concurrent edit


### PR DESCRIPTION
## Summary
- add a download endpoint for project assets including binary response handling and path normalisation
- extend the FastAPI shim and test client to support `:path` parameters and binary payload assertions
- document the new route and cover it with API tests while updating the tasks backlog

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e301e729b48324a9d79e01360463ba