### PR TITLE
Add CLI high contrast palette toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ TASKS.md                   # Planning notes and backlog ideas
  ```
 Run `python src/main.py --help` to discover options for enabling persistence
  (`--session-dir`, `--session-id`, `--no-persistence`) and transcript logging
- (`--log-file`). Use `--scene-path` (or the `TEXTADVENTURE_SCENE_PATH`
+ (`--log-file`). Enable a high-contrast colour palette with `--high-contrast`
+ to make narration and choices easier to read. Use `--scene-path` (or the `TEXTADVENTURE_SCENE_PATH`
  environment variable) to load scenes from an external JSON file. When
  configured the CLI watches the file for changes and reloads the story between
  turns, making it easy to iterate alongside the editor API. Configure the

--- a/TASKS.md
+++ b/TASKS.md
@@ -345,7 +345,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Common action shortcuts
       - [ ] Tab navigation
       - [ ] Screen reader support
-      - [ ] High contrast mode
+      - [x] High contrast mode *(Added a `--high-contrast` CLI flag that swaps in a brighter Markdown palette with documentation and tests.)*
     - [ ] Create help system:
       - [x] Interactive tutorials *(Added a CLI `tutorial` command with a guided walkthrough covering choices, system commands, and persistence tips.)*
       - [x] Context-sensitive help *(Added a CLI `help` command that surfaces current story choices alongside system command guidance.)*

--- a/docs/feature_reference.md
+++ b/docs/feature_reference.md
@@ -15,6 +15,9 @@ is available and where to look next.
 - Command-line flags configure persistence, transcript logging, and LLM
   co-narrators (see `--session-dir`, `--log-file`, `--llm-provider`,
   `--llm-config`, and repeated `--llm-option key=value`).【F:src/main.py†L218-L268】
+- Accessibility helpers include the `--high-contrast` flag, which swaps in a
+  brighter ANSI palette for narration and choice text so the CLI remains legible
+  in low-vision or low-contrast setups.【F:src/main.py†L218-L323】【F:src/textadventure/markdown.py†L9-L133】
 
 ## Multi-Agent Narration & LLM Integration
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,6 +64,19 @@ python src/main.py \
 - `--session-id` controls the save-file prefix so multiple runs can coexist.
 - `--log-file` writes a structured transcript containing narration, player input, and agent metadata.
 
+### Improve CLI Readability
+
+Switch to a brighter colour palette when running the CLI in low-light or
+low-vision environments:
+
+```bash
+python src/main.py --high-contrast
+```
+
+The `--high-contrast` flag tweaks heading colours, list bullets, and inline
+formatting so narration and choices stand out more clearly on terminals with
+reduced contrast or accessibility themes.
+
 ### Launch the Scene Editor API
 
 Type `editor` inside the CLI to start the FastAPI application that powers the web-based scene editor. The command reports the local URL and supports `editor stop`/`editor status` for lifecycle control. Configure the binding with the following command-line flags when starting the CLI:

--- a/src/main.py
+++ b/src/main.py
@@ -13,15 +13,19 @@ from typing import Mapping, Sequence, TextIO, cast
 
 from textadventure import (
     FileSessionStore,
+    HIGH_CONTRAST_PALETTE,
     LLMProviderRegistry,
     LLMStoryAgent,
     MultiAgentCoordinator,
+    MarkdownPalette,
     ScriptedStoryAgent,
     SessionSnapshot,
     SessionStore,
     StoryEngine,
     StoryEvent,
     WorldState,
+    get_markdown_palette,
+    set_markdown_palette,
 )
 from textadventure.llm_providers import register_builtin_providers
 from textadventure.scripted_story_engine import (
@@ -823,6 +827,14 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "May be supplied multiple times."
         ),
     )
+    parser.add_argument(
+        "--high-contrast",
+        action="store_true",
+        help=(
+            "Render narration and choices with a high-contrast colour palette "
+            "suited to low-vision accessibility."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -950,7 +962,11 @@ def main(argv: Sequence[str] | None = None) -> None:
 
     transcript_logger: TranscriptLogger | None = None
     log_handle: TextIO | None = None
+    previous_palette: MarkdownPalette | None = None
     try:
+        if args.high_contrast:
+            previous_palette = get_markdown_palette()
+            set_markdown_palette(HIGH_CONTRAST_PALETTE)
         if args.log_file is not None:
             args.log_file.parent.mkdir(parents=True, exist_ok=True)
             log_handle = args.log_file.open("a", encoding="utf-8")
@@ -966,6 +982,8 @@ def main(argv: Sequence[str] | None = None) -> None:
             dataset_monitor=dataset_monitor,
         )
     finally:
+        if previous_palette is not None:
+            set_markdown_palette(previous_palette)
         if log_handle is not None:
             log_handle.close()
 

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -48,7 +48,14 @@ from .scripted_story_engine import (
     load_scenes_from_file,
     load_scenes_from_mapping,
 )
-from .markdown import render_markdown
+from .markdown import (
+    DEFAULT_PALETTE,
+    HIGH_CONTRAST_PALETTE,
+    MarkdownPalette,
+    get_markdown_palette,
+    render_markdown,
+    set_markdown_palette,
+)
 from .multi_agent import (
     Agent,
     AgentTrigger,
@@ -144,7 +151,12 @@ __all__ = [
     "search_scene_text_from_definitions",
     "search_scene_text_from_file",
     "replace_scene_text_in_definitions",
+    "MarkdownPalette",
+    "DEFAULT_PALETTE",
+    "HIGH_CONTRAST_PALETTE",
+    "get_markdown_palette",
     "render_markdown",
+    "set_markdown_palette",
     "Tool",
     "ToolResponse",
     "KnowledgeBaseTool",

--- a/src/textadventure/markdown.py
+++ b/src/textadventure/markdown.py
@@ -3,20 +3,56 @@
 from __future__ import annotations
 
 import re
-from typing import Iterable
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
 
-RESET = "\033[0m"
-BOLD = "\033[1m"
-ITALIC = "\033[3m"
-UNDERLINE = "\033[4m"
-FAINT = "\033[2m"
-CODE = "\033[38;5;214m"
-HEADING_COLOURS = {
-    1: "\033[95m",  # magenta
-    2: "\033[94m",  # blue
-    3: "\033[92m",  # green
-}
-BULLET_SYMBOL = "•"
+
+@dataclass(frozen=True)
+class MarkdownPalette:
+    """ANSI styling applied when rendering Markdown text for the CLI."""
+
+    reset: str = "\033[0m"
+    bold: str = "\033[1m"
+    italic: str = "\033[3m"
+    underline: str = "\033[4m"
+    faint: str = "\033[2m"
+    code: str = "\033[38;5;214m"
+    heading_colours: Mapping[int, str] = field(
+        default_factory=lambda: {1: "\033[95m", 2: "\033[94m", 3: "\033[92m"}
+    )
+    bullet_symbol: str = "•"
+
+
+DEFAULT_PALETTE = MarkdownPalette()
+"""Palette mirroring the original CLI colours."""
+
+HIGH_CONTRAST_PALETTE = MarkdownPalette(
+    bold="\033[1m",
+    italic="\033[3m",
+    underline="\033[4m",
+    faint="\033[1m",
+    code="\033[97;44m",
+    heading_colours={1: "\033[97m", 2: "\033[93m", 3: "\033[96m"},
+    bullet_symbol="*",
+)
+"""Palette tuned for brighter, higher-contrast output."""
+
+_ACTIVE_PALETTE: MarkdownPalette = DEFAULT_PALETTE
+
+
+def set_markdown_palette(palette: MarkdownPalette) -> None:
+    """Set the global palette used by :func:`render_markdown`."""
+
+    global _ACTIVE_PALETTE
+    _ACTIVE_PALETTE = palette
+
+
+def get_markdown_palette() -> MarkdownPalette:
+    """Return the palette currently used by :func:`render_markdown`."""
+
+    return _ACTIVE_PALETTE
+
+
 ORDERED_LIST_PATTERN = re.compile(r"^(\d+)[.)]\s+(.*)")
 LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 BOLD_PATTERN = re.compile(r"(\*\*|__)(.+?)\1")
@@ -41,7 +77,7 @@ def _restore_escapes(text: str, escapes: Iterable[tuple[str, str]]) -> str:
     return text
 
 
-def _apply_inline_styles(text: str) -> str:
+def _apply_inline_styles(text: str, palette: MarkdownPalette) -> str:
     """Apply inline Markdown formatting (bold, italics, code, links)."""
 
     escapes: list[tuple[str, str]] = []
@@ -54,17 +90,17 @@ def _apply_inline_styles(text: str) -> str:
     text = ESCAPED_CHAR_PATTERN.sub(_replace_escape, text)
 
     def _replace_code(match: re.Match[str]) -> str:
-        return f"{CODE}{match.group(1)}{RESET}"
+        return f"{palette.code}{match.group(1)}{palette.reset}"
 
     text = CODE_PATTERN.sub(_replace_code, text)
 
     def _replace_bold(match: re.Match[str]) -> str:
-        return f"{BOLD}{match.group(2)}{RESET}"
+        return f"{palette.bold}{match.group(2)}{palette.reset}"
 
     text = BOLD_PATTERN.sub(_replace_bold, text)
 
     def _replace_italic(match: re.Match[str]) -> str:
-        return f"{ITALIC}{match.group(1)}{RESET}"
+        return f"{palette.italic}{match.group(1)}{palette.reset}"
 
     text = ITALIC_STAR_PATTERN.sub(_replace_italic, text)
     text = ITALIC_UNDERSCORE_PATTERN.sub(_replace_italic, text)
@@ -72,7 +108,7 @@ def _apply_inline_styles(text: str) -> str:
     def _replace_link(match: re.Match[str]) -> str:
         label = match.group(1)
         url = match.group(2)
-        styled_label = f"{UNDERLINE}{label}{RESET}"
+        styled_label = f"{palette.underline}{label}{palette.reset}"
         return f"{styled_label} ({url})"
 
     text = LINK_PATTERN.sub(_replace_link, text)
@@ -80,9 +116,10 @@ def _apply_inline_styles(text: str) -> str:
     return _restore_escapes(text, escapes)
 
 
-def render_markdown(text: str) -> str:
+def render_markdown(text: str, *, palette: MarkdownPalette | None = None) -> str:
     """Render a Markdown string to ANSI-coloured text suitable for the CLI."""
 
+    active_palette = palette or _ACTIVE_PALETTE
     lines = text.splitlines()
     rendered: list[str] = []
 
@@ -97,9 +134,9 @@ def render_markdown(text: str) -> str:
         if stripped.startswith("#"):
             level = len(stripped) - len(stripped.lstrip("#"))
             content = stripped[level:].strip()
-            inline = _apply_inline_styles(content)
-            colour = HEADING_COLOURS.get(level, BOLD)
-            heading_text = f"{colour}{inline}{RESET}"
+            inline = _apply_inline_styles(content, active_palette)
+            colour = active_palette.heading_colours.get(level, active_palette.bold)
+            heading_text = f"{colour}{inline}{active_palette.reset}"
             rendered.append(f"{indent}{heading_text}")
             underline_char = "=" if level == 1 else "-" if level == 2 else "~"
             underline = underline_char * max(_strip_ansi_length(inline), 1)
@@ -108,26 +145,35 @@ def render_markdown(text: str) -> str:
 
         if stripped.startswith("> "):
             content = stripped[2:].strip()
-            inline = _apply_inline_styles(content)
-            rendered.append(f"{indent}{FAINT}> {inline}{RESET}")
+            inline = _apply_inline_styles(content, active_palette)
+            rendered.append(
+                f"{indent}{active_palette.faint}> {inline}{active_palette.reset}"
+            )
             continue
 
         if stripped.startswith(("- ", "* ", "+ ")):
             content = stripped[2:].strip()
-            inline = _apply_inline_styles(content)
-            rendered.append(f"{indent}{BULLET_SYMBOL} {inline}")
+            inline = _apply_inline_styles(content, active_palette)
+            rendered.append(f"{indent}{active_palette.bullet_symbol} {inline}")
             continue
 
         ordered = ORDERED_LIST_PATTERN.match(stripped)
         if ordered:
             index, content = ordered.groups()
-            inline = _apply_inline_styles(content.strip())
+            inline = _apply_inline_styles(content.strip(), active_palette)
             rendered.append(f"{indent}{index}. {inline}")
             continue
 
-        rendered.append(f"{indent}{_apply_inline_styles(stripped)}")
+        rendered.append(f"{indent}{_apply_inline_styles(stripped, active_palette)}")
 
     return "\n".join(rendered)
 
 
-__all__ = ["render_markdown"]
+__all__ = [
+    "MarkdownPalette",
+    "DEFAULT_PALETTE",
+    "HIGH_CONTRAST_PALETTE",
+    "get_markdown_palette",
+    "render_markdown",
+    "set_markdown_palette",
+]

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from textadventure.markdown import render_markdown
+from textadventure.markdown import (
+    HIGH_CONTRAST_PALETTE,
+    get_markdown_palette,
+    render_markdown,
+    set_markdown_palette,
+)
 
 
 def test_render_markdown_applies_inline_styles() -> None:
@@ -20,3 +25,16 @@ def test_render_markdown_handles_headings_and_lists() -> None:
     assert "=" * len("Heading") in result
     assert "• First item" in result
     assert "• Second item" in result
+
+
+def test_render_markdown_supports_high_contrast_palette() -> None:
+    previous = get_markdown_palette()
+    try:
+        set_markdown_palette(HIGH_CONTRAST_PALETTE)
+        text = """# Heading\n\n- Item"""
+        result = render_markdown(text)
+
+        assert "\033[97mHeading\033[0m" in result
+        assert "* Item" in result
+    finally:
+        set_markdown_palette(previous)


### PR DESCRIPTION
## Summary
- add a configurable Markdown palette with a high-contrast preset for CLI output
- expose a `--high-contrast` flag in the adventure CLI and restore the previous palette after execution
- document the accessibility option and cover it with unit tests

## Testing
- pytest -q
- mypy src
- ruff check src tests
- black --check src tests

------
https://chatgpt.com/codex/tasks/task_e_68e30a5efd348324b308cd221f798829