### PR TITLE
Document OpenAPI metadata for editor API

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -161,7 +161,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Command uniqueness validation
     - [ ] Implement WebSocket endpoint for live adventure testing.
     - [ ] Add unit tests covering all API endpoints and validation logic.
-    - [ ] Document API specification with OpenAPI/Swagger.
+    - [x] Document API specification with OpenAPI/Swagger. *(Documented the FastAPI OpenAPI/Swagger workflow and added tagged metadata so the auto-generated docs surface grouped endpoints.)*
 
   - [ ] **Phase 2: Core Frontend Architecture**
     - [ ] Set up React application with TypeScript for type safety.

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -112,3 +112,29 @@ services.
 
 Use this reference alongside the architecture overview to dive deeper into specific
 modules when extending the engine or integrating new agent capabilities.
+
+## OpenAPI & Swagger Documentation
+
+The FastAPI service automatically publishes a comprehensive OpenAPI specification and
+interactive Swagger UI. After launching the editor API (for example via
+`python -m uvicorn textadventure.api.app:create_app --factory` or the CLI `editor`
+command), visit:
+
+- **`/openapi.json`** – Machine-readable OpenAPI schema capturing all request and
+  response models, tags, and error formats. This is ideal for generating client
+  SDKs or running automated contract tests.
+- **`/docs`** – Swagger UI that lets you explore tagged endpoints, inspect
+  request/response examples, and execute calls against a running server.
+
+Endpoints are grouped under the following tags to make exploration easier:
+
+- **Scenes** – CRUD, validation, analytics, and import/export workflows for scripted
+  scenes.
+- **Scene Branches** – Snapshot management for experimental branches.
+- **Search** – Full-text queries with field-type and validation filters.
+- **Projects** – Project discovery plus asset and collaborator management.
+- **Project Templates** – Template catalogue and instantiation helpers for spinning
+  up new adventures.
+
+Use these resources to integrate tooling, generate client libraries, or confirm the
+expected payloads when extending the backend.

--- a/src/textadventure/api/app.py
+++ b/src/textadventure/api/app.py
@@ -3429,9 +3429,60 @@ def create_app(
             project_service=project,
         )
 
-    app = FastAPI(title="Text Adventure Scene API", version="0.1.0")
+    tags_metadata = [
+        {
+            "name": "Scenes",
+            "description": (
+                "CRUD operations, validation, analytics, and import/export for "
+                "scripted adventure scenes."
+            ),
+        },
+        {
+            "name": "Scene Branches",
+            "description": (
+                "Create and manage experimental scene branches for iterative "
+                "story development."
+            ),
+        },
+        {
+            "name": "Search",
+            "description": (
+                "Full-text search with filtering across the scripted scene "
+                "catalogue."
+            ),
+        },
+        {
+            "name": "Projects",
+            "description": (
+                "Manage adventure projects, including asset inventories and "
+                "collaborator rosters exposed to editor tooling."
+            ),
+        },
+        {
+            "name": "Project Templates",
+            "description": (
+                "Discover reusable templates and instantiate new projects "
+                "from curated datasets."
+            ),
+        },
+    ]
 
-    @app.get("/api/scenes", response_model=SceneListResponse)
+    app = FastAPI(
+        title="Text Adventure Scene API",
+        version="0.1.0",
+        description=(
+            "HTTP API powering the text adventure editor and analytics suite. "
+            "The service exposes endpoints for scripted scenes, validation "
+            "reports, search, project assets, and template management."
+        ),
+        openapi_tags=tags_metadata,
+    )
+
+    @app.get(
+        "/api/scenes",
+        response_model=SceneListResponse,
+        tags=["Scenes"],
+    )
     def get_scenes(
         *,
         search: str | None = Query(
@@ -3465,7 +3516,11 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.get("/api/scenes/{scene_id}", response_model=SceneDetailResponse)
+    @app.get(
+        "/api/scenes/{scene_id}",
+        response_model=SceneDetailResponse,
+        tags=["Scenes"],
+    )
     def get_scene(
         scene_id: str,
         *,
@@ -3485,7 +3540,11 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.put("/api/scenes/{scene_id}", response_model=SceneMutationResponse)
+    @app.put(
+        "/api/scenes/{scene_id}",
+        response_model=SceneMutationResponse,
+        tags=["Scenes"],
+    )
     def update_scene_endpoint(
         scene_id: str, payload: SceneUpdateRequest
     ) -> SceneMutationResponse:
@@ -3511,7 +3570,11 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.get("/api/scenes/graph", response_model=SceneGraphResponse)
+    @app.get(
+        "/api/scenes/graph",
+        response_model=SceneGraphResponse,
+        tags=["Scenes"],
+    )
     def get_scene_graph(
         start_scene: str | None = Query(
             None,
@@ -3528,7 +3591,11 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.get("/api/search", response_model=SceneSearchResponse)
+    @app.get(
+        "/api/search",
+        response_model=SceneSearchResponse,
+        tags=["Search"],
+    )
     def search_scenes(
         query: str = Query(
             ..., min_length=1, description="Case-insensitive text to search for."
@@ -3564,7 +3631,11 @@ def create_app(
 
         return _build_search_response(results, limit=limit)
 
-    @app.get("/api/scenes/validate", response_model=SceneValidationResponse)
+    @app.get(
+        "/api/scenes/validate",
+        response_model=SceneValidationResponse,
+        tags=["Scenes"],
+    )
     def validate_scenes(
         start_scene: str = Query(
             "starting-area",
@@ -3580,7 +3651,11 @@ def create_app(
 
         return SceneValidationResponse(data=report)
 
-    @app.get("/api/export/scenes", response_model=None)
+    @app.get(
+        "/api/export/scenes",
+        response_model=None,
+        tags=["Scenes"],
+    )
     def export_scenes(
         ids: str | None = Query(
             None,
@@ -3623,7 +3698,11 @@ def create_app(
             export_format=export_format,
         )
 
-    @app.post("/api/import/scenes", response_model=SceneImportResponse)
+    @app.post(
+        "/api/import/scenes",
+        response_model=SceneImportResponse,
+        tags=["Scenes"],
+    )
     def import_scenes(payload: SceneImportRequest) -> SceneImportResponse:
         try:
             return service.validate_import_payload(
@@ -3636,7 +3715,11 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.post("/api/scenes/rollback", response_model=SceneRollbackResponse)
+    @app.post(
+        "/api/scenes/rollback",
+        response_model=SceneRollbackResponse,
+        tags=["Scenes"],
+    )
     def plan_rollback(payload: SceneRollbackRequest) -> SceneRollbackResponse:
         try:
             return service.plan_rollback(
@@ -3649,7 +3732,11 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.get("/api/scenes/branches", response_model=SceneBranchListResponse)
+    @app.get(
+        "/api/scenes/branches",
+        response_model=SceneBranchListResponse,
+        tags=["Scene Branches"],
+    )
     def list_branches() -> SceneBranchListResponse:
         try:
             return service.list_branches()
@@ -3659,6 +3746,7 @@ def create_app(
     @app.get(
         "/api/scenes/branches/{branch_id}",
         response_model=SceneBranchDetailResponse,
+        tags=["Scene Branches"],
     )
     def get_branch(branch_id: str) -> SceneBranchDetailResponse:
         try:
@@ -3672,6 +3760,7 @@ def create_app(
         "/api/scenes/branches",
         response_model=SceneBranchResource,
         status_code=201,
+        tags=["Scene Branches"],
     )
     def create_branch(payload: SceneBranchCreateRequest) -> SceneBranchResource:
         try:
@@ -3693,6 +3782,7 @@ def create_app(
         "/api/scenes/branches/{branch_id}",
         response_model=None,
         status_code=204,
+        tags=["Scene Branches"],
     )
     def delete_branch(branch_id: str) -> None:
         try:
@@ -3705,6 +3795,7 @@ def create_app(
     @app.post(
         "/api/scenes/branches/plan",
         response_model=SceneBranchPlanResponse,
+        tags=["Scene Branches"],
     )
     def plan_branch(payload: SceneBranchPlanRequest) -> SceneBranchPlanResponse:
         try:
@@ -3720,7 +3811,11 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.post("/api/scenes/diff", response_model=SceneDiffResponse)
+    @app.post(
+        "/api/scenes/diff",
+        response_model=SceneDiffResponse,
+        tags=["Scenes"],
+    )
     def diff_scenes(payload: SceneDiffRequest) -> SceneDiffResponse:
         try:
             return service.diff_scenes(
@@ -3732,7 +3827,11 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.get("/api/projects", response_model=AdventureProjectListResponse)
+    @app.get(
+        "/api/projects",
+        response_model=AdventureProjectListResponse,
+        tags=["Projects"],
+    )
     def list_projects() -> AdventureProjectListResponse:
         if project is None:
             raise HTTPException(404, "Project management endpoints are not enabled.")
@@ -3747,6 +3846,7 @@ def create_app(
     @app.get(
         "/api/projects/{project_id}",
         response_model=AdventureProjectDetailResponse,
+        tags=["Projects"],
     )
     def get_project(project_id: str) -> AdventureProjectDetailResponse:
         if project is None:
@@ -3764,6 +3864,7 @@ def create_app(
     @app.get(
         "/api/projects/{project_id}/assets",
         response_model=ProjectAssetListResponse,
+        tags=["Projects"],
     )
     def list_project_assets(project_id: str) -> ProjectAssetListResponse:
         if project is None:
@@ -3778,7 +3879,10 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    @app.get("/api/projects/{project_id}/assets/{asset_path:path}")
+    @app.get(
+        "/api/projects/{project_id}/assets/{asset_path:path}",
+        tags=["Projects"],
+    )
     def get_project_asset(project_id: str, asset_path: str) -> BinaryResponse:
         if project is None:
             raise HTTPException(404, "Project management endpoints are not enabled.")
@@ -3801,6 +3905,7 @@ def create_app(
     @app.put(
         "/api/projects/{project_id}/assets/{asset_path:path}",
         response_model=ProjectAssetResource,
+        tags=["Projects"],
     )
     def upload_project_asset(
         project_id: str,
@@ -3827,6 +3932,7 @@ def create_app(
     @app.delete(
         "/api/projects/{project_id}/assets/{asset_path:path}",
         status_code=204,
+        tags=["Projects"],
     )
     def delete_project_asset(project_id: str, asset_path: str) -> None:
         if project is None:
@@ -3844,6 +3950,7 @@ def create_app(
     @app.get(
         "/api/projects/{project_id}/collaborators",
         response_model=ProjectCollaboratorListResponse,
+        tags=["Projects"],
     )
     def list_project_collaborators(
         project_id: str,
@@ -3863,6 +3970,7 @@ def create_app(
     @app.put(
         "/api/projects/{project_id}/collaborators",
         response_model=ProjectCollaboratorListResponse,
+        tags=["Projects"],
     )
     def replace_project_collaborators(
         project_id: str, payload: ProjectCollaboratorUpdateRequest
@@ -3884,6 +3992,7 @@ def create_app(
     @app.get(
         "/api/project-templates",
         response_model=AdventureProjectTemplateListResponse,
+        tags=["Project Templates"],
     )
     def list_project_templates() -> AdventureProjectTemplateListResponse:
         if template_service is None:
@@ -3900,6 +4009,7 @@ def create_app(
         "/api/project-templates/{template_id}/instantiate",
         response_model=AdventureProjectDetailResponse,
         status_code=201,
+        tags=["Project Templates"],
     )
     def instantiate_project_template(
         template_id: str, payload: ProjectTemplateInstantiateRequest

--- a/tests/test_api_scenes.py
+++ b/tests/test_api_scenes.py
@@ -76,6 +76,31 @@ def _write_dataset(path: Path, payload: Mapping[str, Any]) -> None:
         json.dump(payload, handle)
 
 
+def test_openapi_documents_tag_metadata() -> None:
+    client = _client()
+
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    schema = response.json()
+    assert schema["info"]["description"].startswith(
+        "HTTP API powering the text adventure editor"
+    )
+
+    tags = {entry["name"]: entry for entry in schema.get("tags", [])}
+    expected_tags = {
+        "Scenes",
+        "Scene Branches",
+        "Search",
+        "Projects",
+        "Project Templates",
+    }
+
+    assert expected_tags.issubset(tags.keys())
+    assert "scripted adventure scenes" in tags["Scenes"]["description"]
+    assert "experimental scene branches" in tags["Scene Branches"]["description"]
+
+
 def test_list_scenes_returns_expected_summary_fields() -> None:
     client = _client()
 


### PR DESCRIPTION
## Summary
- add descriptive OpenAPI metadata and grouped tags to the editor FastAPI application
- extend the lightweight FastAPI test shim to expose the generated schema and respect route tags
- document how to access the Swagger/OpenAPI docs and cover the schema with a regression test

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e323818d888324ba686bfbee88a499