### PR TITLE
Add live playtest websocket endpoint

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -159,7 +159,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Reachability analysis (unreachable scenes/items)
       - [ ] Circular dependency detection
       - [ ] Command uniqueness validation
-    - [ ] Implement WebSocket endpoint for live adventure testing.
+    - [x] Implement WebSocket endpoint for live adventure testing.
     - [ ] Add unit tests covering all API endpoints and validation logic.
       - [x] Added regression coverage for the create/delete endpoints and import/export aliases.
     - [x] Document API specification with OpenAPI/Swagger. *(Documented the FastAPI OpenAPI/Swagger workflow and added tagged metadata so the auto-generated docs surface grouped endpoints.)*

--- a/src/fastapi/__init__.py
+++ b/src/fastapi/__init__.py
@@ -1,5 +1,5 @@
 """Minimal FastAPI-compatible shim for local development."""
 
-from .app import FastAPI, HTTPException, Query
+from .app import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
 
-__all__ = ["FastAPI", "HTTPException", "Query"]
+__all__ = ["FastAPI", "HTTPException", "Query", "WebSocket", "WebSocketDisconnect"]

--- a/src/fastapi/testclient.py
+++ b/src/fastapi/testclient.py
@@ -3,11 +3,23 @@
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import asdict, is_dataclass
 from datetime import datetime
-from typing import Any, Mapping
+from queue import Empty
+from typing import Any, Mapping, Literal
+from urllib.parse import parse_qsl, urlparse
 
-from .app import FastAPI, HTTPException
+from .app import (
+    FastAPI,
+    HTTPException,
+    WebSocket,
+    WebSocketDisconnect,
+    _ClientCloseEvent,
+    _ServerCloseMessage,
+    _WebSocketState,
+    _build_keyword_arguments,
+)
 
 
 class _Response:
@@ -96,6 +108,19 @@ class TestClient:
         payload, text, content, headers = _serialise(result)
         return _Response(status, payload, text, headers=headers, content=content)
 
+    def websocket(self, path: str) -> "_WebSocketSession":
+        parsed = urlparse(path)
+        route_path = parsed.path or "/"
+        route, path_params = self._app._resolve_websocket(route_path)
+        query_params = dict(parse_qsl(parsed.query, keep_blank_values=True))
+        state = _WebSocketState(
+            route=route,
+            path=route_path,
+            path_params=path_params,
+            query_params=query_params,
+        )
+        return _WebSocketSession(state)
+
 
 def _serialise(value: Any) -> tuple[Any, str | None, bytes | None, Mapping[str, Any]]:
     if hasattr(value, "body"):
@@ -143,3 +168,80 @@ def _serialise(value: Any) -> tuple[Any, str | None, bytes | None, Mapping[str, 
     if isinstance(value, datetime):
         return value.isoformat(), None, None, {}
     return value, None, None, {}
+
+
+class _WebSocketClient:
+    """Client-facing handle for interacting with the WebSocket endpoint."""
+
+    def __init__(self, state: _WebSocketState) -> None:
+        self._state = state
+
+    def send_json(self, message: Any) -> None:
+        if self._state.closed:
+            raise RuntimeError("WebSocket connection is closed.")
+        self._state.incoming.put(message)
+
+    def receive_json(self, timeout: float | None = None) -> Any:
+        try:
+            if timeout is None:
+                message = self._state.outgoing.get()
+            else:
+                message = self._state.outgoing.get(timeout=timeout)
+        except Empty as exc:  # pragma: no cover - exercised indirectly
+            raise TimeoutError("Timed out waiting for WebSocket message.") from exc
+
+        if isinstance(message, _ServerCloseMessage):
+            self._state.closed = True
+            self._state.close_code = message.code
+            raise WebSocketDisconnect(message.code)
+
+        return message
+
+    def close(self, code: int = 1000) -> None:
+        if self._state.closed:
+            return
+        self._state.closed = True
+        self._state.close_code = code
+        self._state.incoming.put(_ClientCloseEvent(code))
+
+
+class _WebSocketSession:
+    """Context manager that runs the WebSocket handler in a background thread."""
+
+    def __init__(self, state: _WebSocketState) -> None:
+        self._state = state
+        self._client = _WebSocketClient(state)
+        self._thread = threading.Thread(
+            target=_run_websocket_endpoint, args=(state,), daemon=True
+        )
+
+    def __enter__(self) -> _WebSocketClient:
+        self._thread.start()
+        return self._client
+
+    def __exit__(self, exc_type, exc, tb) -> Literal[False]:
+        if not self._state.closed:
+            self._client.close()
+        self._thread.join()
+        if self._state.exception is not None and exc_type is None:
+            raise self._state.exception
+        return False
+
+
+def _run_websocket_endpoint(state: _WebSocketState) -> None:
+    websocket = WebSocket(state)
+    try:
+        params: dict[str, Any] = dict(state.path_params)
+        params["websocket"] = websocket
+        kwargs = _build_keyword_arguments(state.route.endpoint, params)
+        if "websocket" not in kwargs:
+            kwargs["websocket"] = websocket
+        state.route.endpoint(**kwargs)
+    except WebSocketDisconnect:
+        pass
+    except BaseException as exc:  # pragma: no cover - bubble unexpected errors
+        state.exception = exc
+    finally:
+        if not state.closed:
+            state.closed = True
+            state.outgoing.put(_ServerCloseMessage(state.close_code))

--- a/tests/test_api_playtest.py
+++ b/tests/test_api_playtest.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from textadventure.api.app import SceneProjectStore, create_app
+from textadventure.api.settings import SceneApiSettings
+
+
+def _create_project_dataset(root: Path, identifier: str) -> None:
+    store = SceneProjectStore(root=root)
+    scenes = {
+        "starting-area": {
+            "description": "Custom start location with a gentle breeze.",
+            "choices": [
+                {"command": "wait", "description": "Pause for a moment."},
+            ],
+            "transitions": {
+                "wait": {"narration": "The breeze settles as time passes."}
+            },
+        }
+    }
+    store.create(identifier=identifier, scenes=scenes)
+
+
+def test_playtest_websocket_basic_flow() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    with client.websocket("/api/playtest") as session:
+        initial = session.receive_json()
+        assert initial["type"] == "event"
+        assert "Sunlight filters" in initial["event"]["narration"]
+        assert initial["world"]["location"] == "starting-area"
+        assert initial["world"]["recent_actions"] == []
+
+        session.send_json({"type": "player_input", "input": "explore"})
+        follow_up = session.receive_json()
+        assert follow_up["world"]["location"] == "old-gate"
+        assert "courtyard" in follow_up["event"]["narration"].lower()
+
+
+def test_playtest_websocket_reset_command() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    with client.websocket("/api/playtest") as session:
+        session.receive_json()
+        session.send_json({"type": "player_input", "input": "explore"})
+        session.receive_json()
+
+        session.send_json({"type": "reset"})
+        reset_message = session.receive_json()
+        assert reset_message["world"]["location"] == "starting-area"
+        assert reset_message["world"]["recent_actions"] == []
+
+
+def test_playtest_websocket_configure_project(tmp_path: Path) -> None:
+    _create_project_dataset(tmp_path, "custom")
+    settings = SceneApiSettings(project_root=tmp_path)
+    app = create_app(settings=settings)
+    client = TestClient(app)
+
+    with client.websocket("/api/playtest?project_id=custom") as session:
+        initial = session.receive_json()
+        assert (
+            initial["event"]["narration"]
+            == "Custom start location with a gentle breeze."
+        )
+
+        session.send_json({"type": "player_input", "input": "wait"})
+        after_wait = session.receive_json()
+        assert after_wait["world"]["location"] == "starting-area"
+        assert after_wait["event"]["narration"] == "The breeze settles as time passes."
+
+    with client.websocket("/api/playtest") as session:
+        session.receive_json()
+        session.send_json({"type": "configure", "project_id": "custom"})
+        configured = session.receive_json()
+        assert (
+            configured["event"]["narration"]
+            == "Custom start location with a gentle breeze."
+        )
+
+
+def test_playtest_websocket_reports_invalid_messages() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    with client.websocket("/api/playtest") as session:
+        session.receive_json()
+        session.send_json({"unexpected": "value"})
+        error = session.receive_json()
+        assert error["type"] == "error"
+        assert error["code"] == "invalid-message"
+
+        session.send_json({"type": "configure", "project_id": ""})
+        error = session.receive_json()
+        assert error["code"] == "invalid-project"


### PR DESCRIPTION
## Summary
- add minimal websocket primitives to the shimmed FastAPI app and test client
- implement a live playtest websocket endpoint with supporting models and helpers
- add regression tests exercising the websocket flow and project configuration

## Testing
- `black src tests`
- `ruff check src tests`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e34aaceef083249af852780d761208