### PR TITLE
Add keyboard shortcuts to the CLI for common actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Run `python src/main.py --help` to discover options for enabling persistence
   setup, optional features, and troubleshooting lives in
   [`docs/getting_started.md`](docs/getting_started.md).
 
+Common single-key shortcuts are also available inside the CLI: press `q` to
+quit, `?` for the help overview, `s` for the status summary, and `t` to launch
+the tutorial.
+
 ### Adding an LLM Co-narrator
 
 Use the provider registry flags to experiment with LLM-driven agents alongside

--- a/TASKS.md
+++ b/TASKS.md
@@ -343,7 +343,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Implement utilities to locate structured references with optional filters.
         - [x] Add regression tests covering reference detection scenarios.
     - [ ] Add keyboard shortcuts and accessibility:
-      - [ ] Common action shortcuts
+      - [x] Common action shortcuts *(Added CLI single-key shortcuts for quit/help/status/tutorial with documentation and tests.)*
       - [ ] Tab navigation
       - [ ] Screen reader support
       - [x] High contrast mode *(Added a `--high-contrast` CLI flag that swaps in a brighter Markdown palette with documentation and tests.)*

--- a/src/main.py
+++ b/src/main.py
@@ -444,6 +444,9 @@ def run_cli(
     print("Welcome to the Text Adventure prototype!")
     print("Type 'quit' at any time to end the session.")
     print("Type 'help' for a command overview or 'tutorial' for a guided tour.")
+    print(
+        "Quick shortcuts: 'q' to quit, '?' for help, 's' for status, 't' for the tutorial."
+    )
     if session_store is not None:
         print("Type 'save <name>' or 'load <name>' to manage checkpoints.")
     print()
@@ -467,6 +470,28 @@ def run_cli(
             print(f"\n[scene-watch] {outcome.message}\n")
         if outcome.reloaded:
             event = _capture_event(engine.propose_event(world))
+
+    def _normalise_shortcut(text: str) -> str:
+        trimmed = text.strip()
+        if not trimmed:
+            return trimmed
+
+        lowered = trimmed.lower()
+        shortcuts = {
+            "q": "quit",
+            "h": "help",
+            "s": "status",
+            "t": "tutorial",
+        }
+
+        if trimmed.startswith("?"):
+            remainder = trimmed[1:].lstrip()
+            return "help" if not remainder else f"help {remainder}"
+
+        if lowered in shortcuts:
+            return shortcuts[lowered]
+
+        return trimmed
 
     def _print_help(topic: str | None) -> None:
         if event is None:
@@ -553,6 +578,12 @@ def run_cli(
         print("\nSystem commands:")
         for usage, description in command_help.values():
             print(f"  {usage} - {description}")
+
+        print("\nKeyboard shortcuts:")
+        print("  q - Quit the adventure immediately.")
+        print("  ? - Open this help overview.")
+        print("  s - Show the adventure status summary.")
+        print("  t - Start the interactive tutorial.")
         print()
 
     if session_store is not None and autoload_session:
@@ -593,6 +624,8 @@ def run_cli(
         if not player_input:
             event = _capture_event(engine.propose_event(world))
             continue
+
+        player_input = _normalise_shortcut(player_input)
 
         command, _, argument = player_input.partition(" ")
         command_lower = command.lower()

--- a/tests/data/golden_cli_walkthrough.txt
+++ b/tests/data/golden_cli_walkthrough.txt
@@ -1,6 +1,7 @@
 Welcome to the Text Adventure prototype!
 Type 'quit' at any time to end the session.
 Type 'help' for a command overview or 'tutorial' for a guided tour.
+Quick shortcuts: 'q' to quit, '?' for help, 's' for status, 't' for the tutorial.
 
 Sunlight filters through tall trees at the forest trailhead. An old stone gate lies to the north, while flag-marked paths lead toward a scavenger camp and a ranger lookout.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -418,6 +418,24 @@ def test_help_command_offers_contextual_guidance(monkeypatch, capsys) -> None:
         "No help is available for 'unknown'. Showing general guidance instead."
         in output
     )
+    assert "Keyboard shortcuts:" in output
+
+
+def test_run_cli_supports_common_shortcuts(monkeypatch, capsys) -> None:
+    """Single-character shortcuts should map to the corresponding commands."""
+
+    engine = ScriptedStoryEngine()
+    world = WorldState()
+
+    inputs = iter(["?", "s", "q"])
+    monkeypatch.setattr(builtins, "input", _IteratorInput(inputs))
+
+    run_cli(engine, world)
+
+    output = capsys.readouterr().out
+    assert "=== Help ===" in output
+    assert "=== Adventure Status ===" in output
+    assert "Thanks for playing!" in output
 
 
 def test_transcript_logger_captures_inputs_and_events(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add quick single-key shortcuts for the quit, help, status, and tutorial commands in the CLI loop
- expand the help output, README, and golden transcript to document the new shortcuts
- update tests and planning notes to cover the shortcut behaviour

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3574693208324ae1026cedf330f23