### PR TITLE
Add tab completion support to CLI

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -344,7 +344,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Add regression tests covering reference detection scenarios.
     - [ ] Add keyboard shortcuts and accessibility:
       - [x] Common action shortcuts *(Added CLI single-key shortcuts for quit/help/status/tutorial with documentation and tests.)*
-      - [ ] Tab navigation
+      - [x] Tab navigation *(Added readline-powered tab completion covering system commands, story choices, and editor actions with regression tests and documentation updates.)*
       - [x] Screen reader support *(Added a `--screen-reader` CLI flag that removes ANSI styling, simplifies glyphs, and expands choice descriptions for assistive tech.)*
       - [x] High contrast mode *(Added a `--high-contrast` CLI flag that swaps in a brighter Markdown palette with documentation and tests.)*
     - [ ] Create help system:

--- a/docs/feature_reference.md
+++ b/docs/feature_reference.md
@@ -20,6 +20,9 @@ is available and where to look next.
   in low-vision or low-contrast setups, and the `--screen-reader` flag, which
   removes ANSI styling, simplifies glyphs, and expands choice descriptions to
   improve compatibility with assistive technologies.【F:src/main.py†L218-L327】【F:src/textadventure/markdown.py†L9-L142】【F:src/textadventure/story_engine.py†L61-L97】
+- When readline support is available, pressing <kbd>Tab</kbd> cycles through the
+  current story choices, system commands, and editor actions, making keyboard
+  navigation faster and more discoverable.【F:src/main.py†L603-L734】
 
 ## Multi-Agent Narration & LLM Integration
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,7 @@ Launch the scripted text adventure from the repository root:
 python src/main.py
 ```
 
-The CLI will print the current scene narration, available choices, and a prompt for your next command. Enter `help` to see built-in commands such as `save`, `load`, `status`, `editor`, and `quit`, or type `tutorial` for an interactive walkthrough of the same features.
+The CLI will print the current scene narration, available choices, and a prompt for your next command. Enter `help` to see built-in commands such as `save`, `load`, `status`, `editor`, and `quit`, or type `tutorial` for an interactive walkthrough of the same features. When your environment provides readline support, press <kbd>Tab</kbd> to cycle through available commands, story choices, and editor actions without retyping them.
 
 ### Enable Persistence and Logging
 


### PR DESCRIPTION
## Summary
- add a readline-backed tab completion manager to the CLI loop so commands, choices, and editor actions are discoverable from the prompt
- cover the new completer behaviour with dedicated unit tests and document the keyboard navigation improvement
- mark the tab navigation backlog item as complete in the task list

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e36f550a3083248fc0b1f2cfb5a6f8