### PR TITLE
Add asset bundler CLI for static asset management

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,28 @@ where scene data and branch definitions are loaded from:
 All values accept ``~`` prefixes, making it easy to redirect the service towards
 shared datasets or persistent storage locations.
 
+## Static Asset Bundles
+
+Projects can ship supporting images, audio, or reference files alongside their
+scene data. The API already exposes endpoints for listing, uploading, and
+downloading these assets during development. For production deployments you can
+create versioned bundles with hashed filenames to simplify caching and CDN
+uploads:
+
+```bash
+python -m textadventure.asset_bundler \
+  --root projects/atlas/assets \
+  --output dist/assets
+```
+
+This command writes a ZIP archive such as `assets-20240505T123000Z.zip` together
+with an `assets-manifest.json` manifest summarising each file's checksum, size,
+MIME type, and hashed path inside the archive. Provide `--preserve-filenames` to
+keep original filenames in the bundle, `--bundle-name` to override the archive
+name, or `--manifest-name` to customise the manifest filename. The manifest
+structure mirrors the project asset listing API, making it easy for deployment
+pipelines to decide which files changed between releases.
+
 ## Troubleshooting
 
 Encountering issues with the CLI, persistence, or LLM integrations? Consult the

--- a/TASKS.md
+++ b/TASKS.md
@@ -381,8 +381,9 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [x] Docker containerization *(Added a Dockerfile and README instructions for running the API via Uvicorn in a container.)*
     - [x] Environment configuration *(API now honours environment variables for scene datasets and branch storage with docs and automated tests.)*
     - [ ] Production build optimization
-      - [ ] Static asset management
+      - [x] Static asset management *(Added an asset bundler CLI that produces hashed ZIP archives and manifests for deployment workflows.)*
         - [x] Expose API endpoint to download project asset files for editors.
+        - [x] Generate hashed asset bundles and manifests for deployment via a CLI helper.
       - [x] Provide asset upload and deletion endpoints.
         - [x] Outline upload and deletion API contracts and validation rules.
         - [x] Implement asset storage/deletion logic, FastAPI endpoints, and regression tests.

--- a/src/textadventure/__init__.py
+++ b/src/textadventure/__init__.py
@@ -34,6 +34,7 @@ from .analytics import (
     format_content_distribution_report,
     format_reachability_report,
 )
+from .asset_bundler import AssetBundleResult, BundledAsset, build_asset_bundle
 from .llm import LLMClient, LLMClientError, LLMMessage, LLMResponse, iter_contents
 from .llm_providers import (
     AnthropicMessagesClient,
@@ -129,6 +130,9 @@ __all__ = [
     "format_complexity_report",
     "format_content_distribution_report",
     "format_reachability_report",
+    "AssetBundleResult",
+    "BundledAsset",
+    "build_asset_bundle",
     "ScriptedStoryEngine",
     "load_scenes_from_file",
     "load_scenes_from_mapping",

--- a/src/textadventure/asset_bundler.py
+++ b/src/textadventure/asset_bundler.py
@@ -1,0 +1,262 @@
+"""Utilities for packaging project assets for production deployments."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import os
+import sys
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class BundledAsset:
+    """Metadata describing a single asset included in a bundle."""
+
+    path: str
+    hashed_path: str
+    size: int
+    checksum: str
+    content_type: str | None
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class AssetBundleResult:
+    """Information about an asset bundle and its generated metadata."""
+
+    root: Path
+    generated_at: datetime
+    archive_path: Path
+    manifest_path: Path
+    assets: list[BundledAsset]
+
+
+__all__ = [
+    "AssetBundleResult",
+    "BundledAsset",
+    "build_asset_bundle",
+    "main",
+]
+
+
+def build_asset_bundle(
+    root: Path,
+    output: Path,
+    *,
+    hashed_naming: bool = True,
+    timestamp: datetime | None = None,
+    bundle_name: str | None = None,
+    manifest_name: str = "assets-manifest.json",
+) -> AssetBundleResult:
+    """Package ``root`` into a ZIP archive and emit a manifest describing its files."""
+
+    root_path = Path(root)
+    if not root_path.exists():
+        raise ValueError(f"Asset root '{root_path}' does not exist.")
+    if not root_path.is_dir():
+        raise ValueError(f"Asset root '{root_path}' must be a directory.")
+
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    generated_at = _normalise_timestamp(timestamp)
+    if bundle_name is None:
+        bundle_name = f"assets-{generated_at.strftime('%Y%m%dT%H%M%SZ')}.zip"
+
+    archive_path = output_path / bundle_name
+    manifest_path = output_path / manifest_name
+
+    files = sorted(_iter_files(root_path))
+    assets: list[BundledAsset] = []
+
+    with zipfile.ZipFile(
+        archive_path, "w", compression=zipfile.ZIP_DEFLATED
+    ) as archive:
+        for file_path in files:
+            relative_path = file_path.relative_to(root_path)
+            checksum = _compute_checksum(file_path)
+            hashed_relative = (
+                _hashed_relative_path(relative_path, checksum)
+                if hashed_naming
+                else relative_path.as_posix()
+            )
+
+            archive.write(file_path, arcname=hashed_relative)
+
+            stat = file_path.stat()
+            updated_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
+            content_type, _ = mimetypes.guess_type(file_path.name)
+            assets.append(
+                BundledAsset(
+                    path=relative_path.as_posix(),
+                    hashed_path=hashed_relative,
+                    size=stat.st_size,
+                    checksum=checksum,
+                    content_type=content_type,
+                    updated_at=updated_at,
+                )
+            )
+
+    assets.sort(key=lambda asset: asset.path)
+
+    manifest_payload = {
+        "root": root_path.name,
+        "generated_at": _format_timestamp(generated_at),
+        "bundle": archive_path.name,
+        "assets": [
+            {
+                "path": asset.path,
+                "hashed_path": asset.hashed_path,
+                "size": asset.size,
+                "checksum": asset.checksum,
+                "content_type": asset.content_type,
+                "updated_at": _format_timestamp(asset.updated_at),
+            }
+            for asset in assets
+        ],
+    }
+
+    manifest_path.write_text(
+        json.dumps(manifest_payload, indent=2, sort_keys=True, ensure_ascii=False)
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return AssetBundleResult(
+        root=root_path,
+        generated_at=generated_at,
+        archive_path=archive_path,
+        manifest_path=manifest_path,
+        assets=assets,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point for building asset bundles."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        result = build_asset_bundle(
+            Path(args.root),
+            Path(args.output),
+            hashed_naming=not args.preserve_filenames,
+            timestamp=args.timestamp,
+            bundle_name=args.bundle_name,
+            manifest_name=args.manifest_name,
+        )
+    except Exception as exc:  # pragma: no cover - exercised via CLI errors
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Wrote {len(result.assets)} assets to {result.archive_path.name} "
+        f"(manifest: {result.manifest_path.name})"
+    )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Bundle project assets into a versioned archive with a manifest.",
+    )
+    parser.add_argument(
+        "--root", required=True, help="Directory containing project assets."
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Directory where the bundle archive and manifest will be written.",
+    )
+    parser.add_argument(
+        "--bundle-name",
+        help="Optional filename for the generated bundle archive. Defaults to a timestamped name.",
+    )
+    parser.add_argument(
+        "--manifest-name",
+        default="assets-manifest.json",
+        help="Filename for the generated manifest. Defaults to 'assets-manifest.json'.",
+    )
+    parser.add_argument(
+        "--preserve-filenames",
+        action="store_true",
+        help="Store original filenames in the archive instead of hashed variants.",
+    )
+    parser.add_argument(
+        "--timestamp",
+        type=_parse_timestamp,
+        help=(
+            "Override the timestamp used for naming and manifest metadata. "
+            "Accepts ISO-8601 strings (defaults to the current UTC time)."
+        ),
+    )
+    return parser
+
+
+def _parse_timestamp(value: str) -> datetime:
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "Timestamp must be an ISO-8601 string (e.g., 2024-05-05T12:30:00Z)."
+        ) from exc
+    return _normalise_timestamp(parsed)
+
+
+def _normalise_timestamp(timestamp: datetime | None) -> datetime:
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    else:
+        timestamp = timestamp.astimezone(timezone.utc)
+    return timestamp.replace(microsecond=0)
+
+
+def _iter_files(root: Path) -> Iterable[Path]:
+    for current_root, _, filenames in os.walk(root):
+        current_path = Path(current_root)
+        for filename in sorted(filenames):
+            file_path = current_path / filename
+            if file_path.is_file():
+                yield file_path
+
+
+def _compute_checksum(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _hashed_relative_path(relative_path: Path, checksum: str) -> str:
+    parent = relative_path.parent
+    suffix = relative_path.suffix
+    if suffix:
+        stem = relative_path.name[: -len(suffix)]
+        filename = f"{stem}.{checksum[:8]}{suffix}"
+    else:
+        filename = f"{relative_path.name}.{checksum[:8]}"
+    if parent == Path("."):
+        return filename
+    return (parent / filename).as_posix()
+
+
+def _format_timestamp(value: datetime) -> str:
+    value = _normalise_timestamp(value)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":  # pragma: no cover - module executable
+    raise SystemExit(main())

--- a/tests/test_asset_bundler.py
+++ b/tests/test_asset_bundler.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from textadventure.asset_bundler import build_asset_bundle
+
+
+def test_build_asset_bundle_creates_archive_and_manifest(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    (asset_root / "images").mkdir(parents=True)
+    (asset_root / "images" / "logo.png").write_bytes(b"logo")
+    (asset_root / "notes.txt").write_text("field guide", encoding="utf-8")
+
+    output_dir = tmp_path / "dist"
+    timestamp = datetime(2024, 5, 5, 12, 30, tzinfo=timezone.utc)
+
+    result = build_asset_bundle(asset_root, output_dir, timestamp=timestamp)
+
+    assert result.archive_path.exists()
+    assert result.manifest_path.exists()
+    assert result.generated_at == timestamp
+
+    # The archive should contain hashed filenames matching the manifest entries.
+    with zipfile.ZipFile(result.archive_path) as archive:
+        archive_names = sorted(archive.namelist())
+        hashed_paths = sorted(asset.hashed_path for asset in result.assets)
+        assert archive_names == hashed_paths
+
+    manifest_payload = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert manifest_payload["bundle"] == result.archive_path.name
+    assert manifest_payload["generated_at"] == "2024-05-05T12:30:00Z"
+
+    notes_entry = next(asset for asset in result.assets if asset.path == "notes.txt")
+    assert notes_entry.size == len("field guide".encode("utf-8"))
+    assert notes_entry.content_type == "text/plain"
+    assert notes_entry.hashed_path.endswith(".txt")
+
+    logo_entry = next(
+        asset for asset in result.assets if asset.path == "images/logo.png"
+    )
+    assert logo_entry.content_type == "image/png"
+    assert logo_entry.hashed_path.startswith("images/")
+    assert logo_entry.hashed_path.endswith(".png")
+
+
+def test_build_asset_bundle_can_preserve_filenames(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    asset_root.mkdir()
+    (asset_root / "manual.pdf").write_bytes(b"pdf")
+
+    output_dir = tmp_path / "dist"
+    timestamp = datetime(2024, 5, 1, 9, 0, tzinfo=timezone.utc)
+
+    result = build_asset_bundle(
+        asset_root,
+        output_dir,
+        timestamp=timestamp,
+        hashed_naming=False,
+        bundle_name="assets.zip",
+        manifest_name="manifest.json",
+    )
+
+    assert result.archive_path.name == "assets.zip"
+    with zipfile.ZipFile(result.archive_path) as archive:
+        assert archive.namelist() == ["manual.pdf"]
+
+    payload = json.loads(result.manifest_path.read_text(encoding="utf-8"))
+    assert payload["generated_at"] == "2024-05-01T09:00:00Z"
+    assert payload["assets"][0]["hashed_path"] == "manual.pdf"
+
+
+def test_build_asset_bundle_requires_directory(tmp_path: Path) -> None:
+    missing_root = tmp_path / "missing"
+    with pytest.raises(ValueError):
+        build_asset_bundle(missing_root, tmp_path)
+
+    file_root = tmp_path / "not_a_directory.txt"
+    file_root.write_text("hello", encoding="utf-8")
+    with pytest.raises(ValueError):
+        build_asset_bundle(file_root, tmp_path)


### PR DESCRIPTION
## Summary
- add an asset bundler module and CLI for generating hashed ZIP archives and manifests for project assets
- expose the bundler in the public package surface and document usage in the README
- cover the bundler helper with dedicated tests and update the static asset management task status

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e3767239b48324b4f276fb961e8f47