### PR TITLE
Add project export archive endpoint

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -401,8 +401,8 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Persist pre-mutation automatic backups with regression tests.
         - [x] Document the automatic backup workflow and settings for operators.
       - [x] Cloud storage integration *(Automatic backups can now mirror to S3-compatible buckets with configuration, docs, and tests covering the upload path.)*
-      - [x] Disaster recovery procedures *(Documented end-to-end recovery runbook covering preparation, rollback validation, and restore execution.)*
-      - [ ] Data export for migration
+    - [x] Disaster recovery procedures *(Documented end-to-end recovery runbook covering preparation, rollback validation, and restore execution.)*
+      - [x] Data export for migration *(Added project export API returning ZIP archives with scenes, metadata, and assets plus regression tests.)*
 
   - [ ] **Phase 10: Documentation & Community**
   - [ ] Create comprehensive user documentation:

--- a/docs/web_editor_api_spec.md
+++ b/docs/web_editor_api_spec.md
@@ -935,6 +935,29 @@ editor workspace or downloading a dataset for offline review.
 }
 ```
 
+### `GET /projects/{project_id}/export`
+
+Download a ZIP archive containing the project's scene dataset, metadata, and
+bundled assets. Useful for migrating adventures between environments or
+capturing an offline backup that mirrors the on-disk layout used by the editor.
+
+**Path parameters**
+
+- `project_id` – Identifier returned by `GET /projects`.
+
+**Response – 200 OK**
+
+- Binary payload with media type `application/zip`.
+- `Content-Disposition` header suggests a filename in the form
+  `atlas-project-export-20240501T100000Z-9a1b2c3d.zip`.
+- Custom headers expose version metadata extracted from the dataset:
+  - `X-TextAdventure-Project-Id`
+  - `X-TextAdventure-Project-Version`
+  - `X-TextAdventure-Project-Checksum`
+- The archive root is the project identifier (for example `atlas/`) and includes
+  `project.json`, the primary scene dataset (for example `scenes.json`), and the
+  entire `assets/` directory tree with empty folders preserved.
+
 ### `GET /projects/{project_id}/assets`
 
 Enumerate static assets stored alongside a project. Responses list directories


### PR DESCRIPTION
## Summary
- add a ProjectExportArchive payload, filesystem exporter, and API route to download full project ZIP archives
- document the new migration export endpoint and mark the backlog task complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e482d80adc8324a56d899e8a68f1f5