### PR TITLE
Validate project collaborator access against user profiles

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -393,6 +393,9 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Expose `/api/users` endpoints for managing user profiles.
         - [x] Cover the user profile workflow with automated tests.
       - [ ] Project sharing and permissions
+        - [x] Validate collaborator assignments reference existing user profiles when a user registry is configured.
+        - [x] Enrich collaborator listings with user profile display names when available.
+        - [ ] Enforce collaborator role restrictions when mutating project resources.
       - [ ] Collaborative editing features
       - [ ] Access control
     - [ ] Implement backup and recovery:


### PR DESCRIPTION
## Summary
- ensure the project service validates collaborator assignments against the configured user registry and enriches responses with stored display names
- pass the optional user service into the project service when building the FastAPI app so collaborator metadata can reference user profiles
- extend the API project tests and backlog tasks to cover collaborator validation behaviour

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4cbf0e6e483249260c7a7a887d08c