### PR TITLE
Enforce collaborator permissions for project mutations

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -395,7 +395,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Project sharing and permissions
         - [x] Validate collaborator assignments reference existing user profiles when a user registry is configured.
         - [x] Enrich collaborator listings with user profile display names when available.
-        - [ ] Enforce collaborator role restrictions when mutating project resources.
+        - [x] Enforce collaborator role restrictions when mutating project resources.
       - [ ] Collaborative editing features
       - [ ] Access control
     - [ ] Implement backup and recovery:


### PR DESCRIPTION
## Summary
- require authorised collaborator roles before allowing asset uploads, deletions, or roster edits
- expose acting_user_id context on project mutation endpoints and surface 403 responses for unauthorised callers
- expand project API tests to cover permission checks and update fixtures to include collaborator metadata

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4dc5dc0948324b5c135b2230dd25a