### PR TITLE
Enforce collaborator access for scene mutations

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -397,7 +397,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Enrich collaborator listings with user profile display names when available.
         - [x] Enforce collaborator role restrictions when mutating project resources.
       - [ ] Collaborative editing features
-      - [ ] Access control
+      - [x] Access control *(Scene and branch mutations now require authorised collaborators with regression coverage.)*
     - [ ] Implement backup and recovery:
       - [x] Automatic backups
         - [x] Add configurable automatic backup directory and retention settings.


### PR DESCRIPTION
## Summary
- enforce project collaborator role checks before mutating scenes or branches when an editable dataset belongs to a project
- expose the repository data path and add helper utilities on the project service to resolve and validate collaborator permissions
- cover the new access control paths with API tests and mark the access-control task complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4dff611008324986298858733fb8b