### PR TITLE
Add container deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,79 @@
+name: Container Deployment
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push the built image to GitHub Container Registry'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+jobs:
+  build-image:
+    name: Build container image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      PUSH_IMAGE: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_image == 'true') }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Log in to GitHub Container Registry
+        if: env.PUSH_IMAGE == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and (optionally) push image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: ${{ env.PUSH_IMAGE == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summarize image build
+        shell: bash
+        run: |
+          {
+            echo "## Image build summary"
+            echo "- Registry: ${REGISTRY}"
+            echo "- Repository: ${IMAGE_NAME}"
+            echo "- Pushed: ${PUSH_IMAGE}"
+            echo "- Tags:"
+            while IFS= read -r tag; do
+              if [[ -n "${tag}" ]]; then
+                echo "  - ${tag}"
+              fi
+            done <<< "${{ steps.meta.outputs.tags }}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/README.md
+++ b/README.md
@@ -289,6 +289,16 @@ The image installs all runtime dependencies and launches Uvicorn with
 `http://localhost:8000/docs` to explore the automatically generated OpenAPI UI
 or hit `/api/scenes` to fetch the bundled demo scenes.
 
+### Automated container builds
+
+Repository maintainers can publish the Docker image without leaving GitHub by
+using the **Container Deployment** workflow. Tag releases that start with `v`
+trigger an automated build that publishes to GitHub Container Registry. You can
+also dispatch the workflow manually and choose whether the build should be
+published or run as a dry run. See
+[`docs/deployment_pipeline.md`](docs/deployment_pipeline.md) for detailed usage
+instructions and configuration tips.
+
 ## Contributing
 
 Read the detailed contributor guidelines in

--- a/TASKS.md
+++ b/TASKS.md
@@ -377,8 +377,10 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [x] Development mode integration
         - [x] Propagate the CLI scene path to the embedded editor server so both share live datasets during authoring.
         - [x] Support an `--editor-reload` flag to launch the embedded server with uvicorn auto-reload for iterative testing.
-    - [ ] Create deployment pipeline:
+    - [x] Create deployment pipeline:
       - [x] Docker containerization *(Added a Dockerfile and README instructions for running the API via Uvicorn in a container.)*
+      - [x] Automated container build workflow *(Added a GitHub Actions workflow that builds/pushes container images to GHCR on demand.)*
+      - [x] Document release pipeline usage *(Documented workflow triggers, manual runs, and registry requirements.)*
     - [x] Environment configuration *(API now honours environment variables for scene datasets and branch storage with docs and automated tests.)*
     - [ ] Production build optimization
       - [x] Static asset management *(Added an asset bundler CLI that produces hashed ZIP archives and manifests for deployment workflows.)*

--- a/docs/deployment_pipeline.md
+++ b/docs/deployment_pipeline.md
@@ -1,0 +1,49 @@
+# Container Deployment Pipeline
+
+This project ships with a GitHub Actions workflow (`Container Deployment`) that
+packages the FastAPI authoring service into a Docker image. The workflow is
+suitable for publishing images to GitHub Container Registry (GHCR) and can also
+be run manually when you only want to verify a build.
+
+## Triggers
+
+The workflow runs automatically whenever a Git tag that starts with `v` is
+pushed (for example, `v1.2.0`). Tag builds log in to GHCR using the
+`GITHUB_TOKEN`, build the container defined by the repository `Dockerfile`, and
+push versioned tags alongside a `latest` tag for convenience.
+
+You can also launch the workflow manually from the Actions tab. The manual
+trigger accepts a `push_image` input so you can choose whether to publish the
+image or simply validate that the build succeeds.
+
+## Image Naming
+
+Images are published to `ghcr.io/<owner>/<repository>`. For example, pushing a
+`v1.2.0` tag from this repository would produce the following tags:
+
+- `ghcr.io/<owner>/textadventure:v1.2.0`
+- `ghcr.io/<owner>/textadventure:latest`
+- `ghcr.io/<owner>/textadventure:sha-<commit-sha>`
+
+The workflow relies on `docker/metadata-action` to keep the tag list in sync and
+to attach build metadata as OCI labels.
+
+## Manual Runs Without Publishing
+
+When launching the workflow via `workflow_dispatch`, set `push_image` to `false`
+to perform a dry run. The workflow will still build the container and generate a
+summary in the Actions log, but it will skip authenticating with GHCR and will
+not upload any images.
+
+If you would like to test a manual publish, set `push_image` to `true`. The
+workflow will authenticate using the `GITHUB_TOKEN` and push tags derived from
+the branch or tag that triggered the run.
+
+## Requirements
+
+The workflow depends on a GitHub-hosted runner with Docker available, which is
+provided automatically by `ubuntu-latest`. No additional secrets are required
+when targeting GHCR because the `GITHUB_TOKEN` is sufficient for pushes to the
+current repository's container namespace. If you decide to push to another
+registry, update the `REGISTRY` value and provide appropriate credentials via
+repository secrets.


### PR DESCRIPTION
## Summary
- add a Container Deployment GitHub Actions workflow that builds and optionally publishes the Docker image to GHCR on tag pushes or manual runs
- document the automated deployment pipeline in a dedicated guide and cross-link it from the README
- update TASKS.md to reflect the completed deployment pipeline work

## Testing
- ruff check src tests
- black --check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4e8e999c48324b225efccdc9b1e70