### PR TITLE
Add collaboration session tracking endpoints

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -398,7 +398,11 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
         - [x] Validate collaborator assignments reference existing user profiles when a user registry is configured.
         - [x] Enrich collaborator listings with user profile display names when available.
         - [x] Enforce collaborator role restrictions when mutating project resources.
-      - [ ] Collaborative editing features
+      - [x] Collaborative editing features
+        - [x] Track active collaboration sessions with TTL persistence.
+        - [x] Expose API endpoints to join, heartbeat, list, and leave sessions.
+        - [x] Cover the collaboration session workflow with automated tests.
+        - [x] Document collaboration session usage for tooling integrators.
       - [x] Access control *(Scene and branch mutations now require authorised collaborators with regression coverage.)*
     - [ ] Implement backup and recovery:
       - [x] Automatic backups

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -136,8 +136,31 @@ Endpoints are grouped under the following tags to make exploration easier:
 - **Scene Branches** – Snapshot management for experimental branches.
 - **Search** – Full-text queries with field-type and validation filters.
 - **Projects** – Project discovery plus asset and collaborator management.
+- **Collaboration Sessions** – Real-time editor presence and locking utilities.
 - **Project Templates** – Template catalogue and instantiation helpers for spinning
   up new adventures.
 
 Use these resources to integrate tooling, generate client libraries, or confirm the
 expected payloads when extending the backend.
+
+### Collaboration Sessions
+
+Projects expose a lightweight collaboration session API so tooling can surface which
+contributors are currently editing a dataset:
+
+- `GET /api/projects/{project_id}/collaboration/sessions` – Returns the active
+  sessions for the project, including collaborator identifiers, resolved display
+  names (when user profiles are available), the optional scene focus, and heartbeat
+  timestamps.
+- `POST /api/projects/{project_id}/collaboration/sessions` – Creates a new session
+  or refreshes an existing one. Provide the acting collaborator via the
+  `acting_user_id` query parameter plus optional `session_id`, `scene_id`, and
+  `ttl_seconds` fields in the JSON payload. The timeout defaults to two minutes and
+  can be extended up to one hour.
+- `DELETE /api/projects/{project_id}/collaboration/sessions/{session_id}` – Ends an
+  active session. Owners or editors may close any session; collaborators with lower
+  privileges may only end their own entries.
+
+Responses include ISO8601 timestamps for when the session started, the latest
+heartbeat, and when it will expire automatically if no further refreshes are
+received.


### PR DESCRIPTION
## Summary
- add collaboration session records, persistence helpers, and ProjectService APIs for active editor sessions
- expose FastAPI endpoints and documentation for collaboration session lifecycle management
- add regression tests for session creation, heartbeats, cleanup, and update the collaborative editing task status

## Testing
- ruff check src tests
- python -m black src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e57a4c3aa48324b90ca5997e30bc3f