### PR TITLE
Add analytics and API reporting for unknown scene targets

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -154,7 +154,7 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [x] `POST /api/scenes/import` - Import JSON scene data *(Provides REST-aligned endpoint alongside legacy path.)*
       - [x] `GET /api/scenes/export` - Export current scenes as JSON *(Adds REST-aligned alias mirroring the legacy endpoint.)*
     - [ ] Add comprehensive validation engine:
-      - [ ] Scene reference integrity (no broken targets)
+      - [x] Scene reference integrity (no broken targets) *(Extended analytics and validation to surface transitions pointing to undefined scenes, with updated API reporting.)*
       - [ ] Item flow analysis (sources vs requirements)
       - [ ] Reachability analysis (unreachable scenes/items)
       - [ ] Circular dependency detection


### PR DESCRIPTION
## Summary
- extend adventure quality analytics to detect transitions pointing to undefined scenes and surface them in formatted reports
- expose the new unknown-target issue category through the FastAPI validation resources and error classification
- add regression tests covering the analytics update and quality report rendering, and mark the corresponding task complete

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5af3fba5c83248323d7b0d7ee94ce