### PR TITLE
Add playtest transcript recorder

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -269,6 +269,9 @@ Revisit this backlog as soon as the initial scaffolding is in place so we can re
       - [ ] Change broadcasting
     - [ ] Implement playtesting features:
       - [ ] Session recording and replay
+        - [x] Add a playtest session transcript recorder that captures player inputs and resulting events for later review.
+        - [ ] Expose API/WebSocket commands to download or clear the recorded transcript from an active session.
+        - [ ] Implement a replay helper that can step through recorded playtest transcripts for automated regression testing.
       - [ ] Path tracking and analytics
       - [ ] Playtester feedback collection
       - [x] A/B testing for narrative variants *(Added analytics comparison helpers, reporting formatters, documentation, and regression coverage for variant deltas.)*

--- a/tests/test_api_playtest.py
+++ b/tests/test_api_playtest.py
@@ -1,11 +1,74 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable
 
 from fastapi.testclient import TestClient
 
-from textadventure.api.app import SceneProjectStore, create_app
+from textadventure.api.app import (
+    PlaytestSession,
+    SceneProjectStore,
+    create_app,
+)
 from textadventure.api.settings import SceneApiSettings
+from textadventure.scripted_story_engine import (
+    ScriptedStoryEngine,
+    load_scenes_from_mapping,
+)
+
+
+def _build_simple_engine_factory() -> Callable[[], ScriptedStoryEngine]:
+    definitions = {
+        "starting-area": {
+            "description": "A quiet clearing.",
+            "choices": [
+                {"command": "wait", "description": "Pause and listen."},
+            ],
+            "transitions": {
+                "wait": {
+                    "narration": "Time drifts by while the forest hums softly.",
+                    "target": "starting-area",
+                }
+            },
+        }
+    }
+
+    def _factory() -> ScriptedStoryEngine:
+        scenes = load_scenes_from_mapping(definitions)
+        return ScriptedStoryEngine(scenes=scenes)
+
+    return _factory
+
+
+def test_playtest_session_records_transcript_entries() -> None:
+    session = PlaytestSession(_build_simple_engine_factory())
+
+    initial_event = session.reset()
+    entries = session.transcript()
+    assert len(entries) == 1
+    assert entries[0].player_input is None
+    assert entries[0].event is initial_event
+
+    follow_up = session.apply_player_input("wait")
+    entries = session.transcript()
+    assert len(entries) == 2
+    assert entries[1].player_input == "wait"
+    assert entries[1].event is follow_up
+    assert "forest hums" in entries[1].event.narration
+
+
+def test_playtest_session_resets_transcript_between_runs() -> None:
+    session = PlaytestSession(_build_simple_engine_factory())
+
+    session.reset()
+    session.apply_player_input("wait")
+    assert len(session.transcript()) == 2
+
+    session.reset()
+    entries = session.transcript()
+    assert len(entries) == 1
+    assert entries[0].turn == 1
+    assert entries[0].player_input is None
 
 
 def _create_project_dataset(root: Path, identifier: str) -> None:


### PR DESCRIPTION
## Summary
- capture playtest turns with a transcript recorder that tracks player input and resulting events
- expose the recorded transcript from `PlaytestSession` and reset it when the session restarts
- add unit tests for the transcript flow and update the task backlog entry

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5eae927648324bc9dd57e0a42b962