### PR TITLE
Extract collaboration routes into dedicated module

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -520,7 +520,7 @@ The repository has grown organically and requires systematic refactoring to impr
   - [ ] Extract project management routes to `routes/projects.py` (list, get, create, update, delete, collaborators, templates, export)
   - [x] Extract marketplace routes to `routes/marketplace.py` (list, get, publish, reviews, search)
   - [x] Extract forum routes to `routes/forum.py` (list threads, create thread, create post, search)
-  - [ ] Extract collaboration routes to `routes/collaboration.py` (sessions, presence, heartbeat, comments)
+  - [x] Extract collaboration routes to `routes/collaboration.py` (sessions, presence, heartbeat, comments)
   - [x] Extract asset management routes to `routes/assets.py` (list, upload, download, delete)
   - [x] Extract playtest/testing routes to `routes/playtest.py` (websocket, transcript, replay)
 - [x] Extract health check routes to `routes/health.py` (health, readiness endpoints)

--- a/src/textadventure/api/app.py
+++ b/src/textadventure/api/app.py
@@ -64,6 +64,7 @@ from .backup import BackupUploadMetadata, BackupUploader, S3BackupUploader
 from .settings import SceneApiSettings
 from .routes import (
     create_assets_router,
+    create_collaboration_router,
     create_playtest_router,
     create_health_router,
     create_marketplace_router,
@@ -134,9 +135,6 @@ from .models import (
     SceneCommentResource,
     SceneCommentThreadResource,
     SceneCommentThreadListResponse,
-    SceneCommentThreadCreateRequest,
-    SceneCommentReplyRequest,
-    SceneCommentResolveRequest,
     # Project models
     AdventureProjectResource,
     AdventureProjectListResponse,
@@ -151,7 +149,6 @@ from .models import (
     ProjectCollaboratorUpdateRequest,
     ProjectCollaborationSessionResource,
     ProjectCollaborationSessionListResponse,
-    ProjectCollaborationSessionRequest,
     # Marketplace models
     MarketplaceEntrySummary,
     MarketplaceReview,
@@ -6090,6 +6087,13 @@ def create_app(
         )
     )
 
+    app.include_router(  # type: ignore[attr-defined]
+        create_collaboration_router(
+            project_service=project,
+            comment_service=comment,
+        )
+    )
+
     @app.get(
         "/api/scenes",
         response_model=SceneListResponse,
@@ -6756,246 +6760,6 @@ def create_app(
             raise HTTPException(status_code=403, detail=str(exc)) from exc
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @app.get(
-        "/api/projects/{project_id}/collaboration/sessions",
-        response_model=ProjectCollaborationSessionListResponse,
-        tags=["Projects"],
-    )
-    def list_project_collaboration_sessions(
-        project_id: str,
-    ) -> ProjectCollaborationSessionListResponse:
-        if project is None:
-            raise HTTPException(404, "Project management endpoints are not enabled.")
-
-        try:
-            return project.list_collaboration_sessions(project_id)
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @app.post(
-        "/api/projects/{project_id}/collaboration/sessions",
-        response_model=ProjectCollaborationSessionListResponse,
-        tags=["Projects"],
-    )
-    def touch_project_collaboration_session(
-        project_id: str,
-        payload: ProjectCollaborationSessionRequest,
-        acting_user_id: str | None = Query(
-            None,
-            description=(
-                "Identifier of the collaborator performing the join or heartbeat."
-            ),
-        ),
-    ) -> ProjectCollaborationSessionListResponse:
-        if project is None:
-            raise HTTPException(404, "Project management endpoints are not enabled.")
-
-        try:
-            return project.touch_collaboration_session(
-                project_id,
-                acting_user_id=acting_user_id,
-                session_id=payload.session_id,
-                scene_id=payload.scene_id,
-                ttl_seconds=payload.ttl_seconds,
-            )
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except ProjectPermissionError as exc:
-            raise HTTPException(status_code=403, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @app.delete(
-        "/api/projects/{project_id}/collaboration/sessions/{session_id}",
-        response_model=ProjectCollaborationSessionListResponse,
-        tags=["Projects"],
-    )
-    def delete_project_collaboration_session(
-        project_id: str,
-        session_id: str,
-        acting_user_id: str | None = Query(
-            None,
-            description=(
-                "Identifier of the collaborator performing the session termination."
-            ),
-        ),
-    ) -> ProjectCollaborationSessionListResponse:
-        if project is None:
-            raise HTTPException(404, "Project management endpoints are not enabled.")
-
-        try:
-            return project.end_collaboration_session(
-                project_id,
-                session_id,
-                acting_user_id=acting_user_id,
-            )
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except ProjectPermissionError as exc:
-            raise HTTPException(status_code=403, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @app.get(
-        "/api/projects/{project_id}/scenes/{scene_id}/comments",
-        response_model=SceneCommentThreadListResponse,
-        tags=["Scene Comments"],
-    )
-    def list_scene_comment_threads(
-        project_id: str,
-        scene_id: str,
-        location_type: SceneCommentLocationType | None = Query(
-            None,
-            description="Optional location type filter when listing comment threads.",
-        ),
-        choice_command: str | None = Query(
-            None,
-            description="Optional transition command filter for comment threads.",
-        ),
-    ) -> SceneCommentThreadListResponse:
-        if comment is None:
-            raise HTTPException(
-                status_code=404,
-                detail="Scene comment functionality is not configured for this deployment.",
-            )
-
-        try:
-            return comment.list_threads(
-                project_id,
-                scene_id,
-                location_type=location_type,
-                choice_command=choice_command,
-            )
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    @app.post(
-        "/api/projects/{project_id}/scenes/{scene_id}/comments",
-        response_model=SceneCommentThreadResource,
-        status_code=201,
-        tags=["Scene Comments"],
-    )
-    def create_scene_comment_thread(
-        project_id: str,
-        scene_id: str,
-        payload: SceneCommentThreadCreateRequest,
-        acting_user_id: str | None = Query(
-            None,
-            description="Identifier of the collaborator creating the comment thread.",
-        ),
-    ) -> SceneCommentThreadResource:
-        if comment is None:
-            raise HTTPException(
-                status_code=404,
-                detail="Scene comment functionality is not configured for this deployment.",
-            )
-
-        try:
-            return comment.create_thread(
-                project_id,
-                scene_id,
-                location=payload.location,
-                body=payload.body,
-                author_id=payload.author_id or acting_user_id,
-                author_display_name=payload.author_display_name,
-                acting_user_id=acting_user_id,
-            )
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ProjectPermissionError as exc:
-            raise HTTPException(status_code=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    @app.post(
-        "/api/projects/{project_id}/scenes/{scene_id}/comments/{thread_id}/replies",
-        response_model=SceneCommentThreadResource,
-        status_code=201,
-        tags=["Scene Comments"],
-    )
-    def add_scene_comment_reply(
-        project_id: str,
-        scene_id: str,
-        thread_id: str,
-        payload: SceneCommentReplyRequest,
-        acting_user_id: str | None = Query(
-            None,
-            description="Identifier of the collaborator adding the inline comment reply.",
-        ),
-    ) -> SceneCommentThreadResource:
-        if comment is None:
-            raise HTTPException(
-                status_code=404,
-                detail="Scene comment functionality is not configured for this deployment.",
-            )
-
-        try:
-            return comment.add_comment(
-                project_id,
-                scene_id,
-                thread_id,
-                body=payload.body,
-                author_id=payload.author_id or acting_user_id,
-                author_display_name=payload.author_display_name,
-                acting_user_id=acting_user_id,
-            )
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ProjectPermissionError as exc:
-            raise HTTPException(status_code=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    @app.post(
-        "/api/projects/{project_id}/scenes/{scene_id}/comments/{thread_id}/resolution",
-        response_model=SceneCommentThreadResource,
-        tags=["Scene Comments"],
-    )
-    def set_scene_comment_resolution(
-        project_id: str,
-        scene_id: str,
-        thread_id: str,
-        payload: SceneCommentResolveRequest,
-        acting_user_id: str | None = Query(
-            None,
-            description="Identifier of the collaborator updating the comment thread resolution state.",
-        ),
-    ) -> SceneCommentThreadResource:
-        if comment is None:
-            raise HTTPException(
-                status_code=404,
-                detail="Scene comment functionality is not configured for this deployment.",
-            )
-
-        try:
-            return comment.set_resolution(
-                project_id,
-                scene_id,
-                thread_id,
-                resolved=payload.resolved,
-                acting_user_id=acting_user_id,
-            )
-        except FileNotFoundError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ProjectPermissionError as exc:
-            raise HTTPException(status_code=403, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     app.include_router(  # type: ignore[attr-defined]
         create_marketplace_router(

--- a/src/textadventure/api/routes/__init__.py
+++ b/src/textadventure/api/routes/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .assets import create_assets_router
+from .collaboration import create_collaboration_router
 from .forum import create_forum_router
 from .health import create_health_router
 from .marketplace import create_marketplace_router
@@ -13,6 +14,7 @@ from .users import create_users_router
 
 __all__ = [
     "create_assets_router",
+    "create_collaboration_router",
     "create_forum_router",
     "create_health_router",
     "create_marketplace_router",

--- a/src/textadventure/api/routes/collaboration.py
+++ b/src/textadventure/api/routes/collaboration.py
@@ -1,0 +1,292 @@
+"""Collaboration-related routes for sessions and inline scene comments."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query  # type: ignore[attr-defined]
+
+from ..models import (
+    ProjectCollaborationSessionListResponse,
+    ProjectCollaborationSessionRequest,
+    ProjectPermissionError,
+    SceneCommentReplyRequest,
+    SceneCommentResolveRequest,
+    SceneCommentThreadCreateRequest,
+    SceneCommentThreadListResponse,
+    SceneCommentThreadResource,
+)
+from ..models.scene import SceneCommentLocationType
+
+
+def create_collaboration_router(
+    *,
+    project_service: Any | None = None,
+    comment_service: Any | None = None,
+) -> APIRouter:
+    """Create the collaboration router with injected service dependencies.
+
+    Args:
+        project_service: Service handling project collaboration sessions.
+        comment_service: Service managing inline scene comment threads.
+
+    Returns:
+        Configured APIRouter instance with collaboration endpoints.
+    """
+
+    router = APIRouter()
+
+    # Collaboration session routes -------------------------------------------------
+
+    @router.get(
+        "/api/projects/{project_id}/collaboration/sessions",
+        response_model=ProjectCollaborationSessionListResponse,
+        tags=["Projects"],
+    )
+    def list_project_collaboration_sessions(
+        project_id: str,
+    ) -> ProjectCollaborationSessionListResponse:
+        if project_service is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Project management endpoints are not enabled.",
+            )
+
+        try:
+            return project_service.list_collaboration_sessions(project_id)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    @router.post(
+        "/api/projects/{project_id}/collaboration/sessions",
+        response_model=ProjectCollaborationSessionListResponse,
+        tags=["Projects"],
+    )
+    def touch_project_collaboration_session(
+        project_id: str,
+        payload: ProjectCollaborationSessionRequest,
+        acting_user_id: str | None = Query(
+            None,
+            description=(
+                "Identifier of the collaborator performing the join or heartbeat."
+            ),
+        ),
+    ) -> ProjectCollaborationSessionListResponse:
+        if project_service is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Project management endpoints are not enabled.",
+            )
+
+        try:
+            return project_service.touch_collaboration_session(
+                project_id,
+                acting_user_id=acting_user_id,
+                session_id=payload.session_id,
+                scene_id=payload.scene_id,
+                ttl_seconds=payload.ttl_seconds,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except ProjectPermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    @router.delete(
+        "/api/projects/{project_id}/collaboration/sessions/{session_id}",
+        response_model=ProjectCollaborationSessionListResponse,
+        tags=["Projects"],
+    )
+    def delete_project_collaboration_session(
+        project_id: str,
+        session_id: str,
+        acting_user_id: str | None = Query(
+            None,
+            description=(
+                "Identifier of the collaborator performing the session termination."
+            ),
+        ),
+    ) -> ProjectCollaborationSessionListResponse:
+        if project_service is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Project management endpoints are not enabled.",
+            )
+
+        try:
+            return project_service.end_collaboration_session(
+                project_id,
+                session_id,
+                acting_user_id=acting_user_id,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except ProjectPermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    # Scene comment routes ---------------------------------------------------------
+
+    @router.get(
+        "/api/projects/{project_id}/scenes/{scene_id}/comments",
+        response_model=SceneCommentThreadListResponse,
+        tags=["Scene Comments"],
+    )
+    def list_scene_comment_threads(
+        project_id: str,
+        scene_id: str,
+        location_type: SceneCommentLocationType | None = Query(
+            None,
+            description="Optional location type filter when listing comment threads.",
+        ),
+        choice_command: str | None = Query(
+            None,
+            description="Optional transition command filter for comment threads.",
+        ),
+    ) -> SceneCommentThreadListResponse:
+        if comment_service is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Scene comment functionality is not configured for this deployment.",
+            )
+
+        try:
+            return comment_service.list_threads(
+                project_id,
+                scene_id,
+                location_type=location_type,
+                choice_command=choice_command,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.post(
+        "/api/projects/{project_id}/scenes/{scene_id}/comments",
+        response_model=SceneCommentThreadResource,
+        status_code=201,
+        tags=["Scene Comments"],
+    )
+    def create_scene_comment_thread(
+        project_id: str,
+        scene_id: str,
+        payload: SceneCommentThreadCreateRequest,
+        acting_user_id: str | None = Query(
+            None,
+            description="Identifier of the collaborator creating the comment thread.",
+        ),
+    ) -> SceneCommentThreadResource:
+        if comment_service is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Scene comment functionality is not configured for this deployment.",
+            )
+
+        try:
+            return comment_service.create_thread(
+                project_id,
+                scene_id,
+                location=payload.location,
+                body=payload.body,
+                author_id=payload.author_id or acting_user_id,
+                author_display_name=payload.author_display_name,
+                acting_user_id=acting_user_id,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ProjectPermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.post(
+        "/api/projects/{project_id}/scenes/{scene_id}/comments/{thread_id}/replies",
+        response_model=SceneCommentThreadResource,
+        status_code=201,
+        tags=["Scene Comments"],
+    )
+    def add_scene_comment_reply(
+        project_id: str,
+        scene_id: str,
+        thread_id: str,
+        payload: SceneCommentReplyRequest,
+        acting_user_id: str | None = Query(
+            None,
+            description="Identifier of the collaborator adding the inline comment reply.",
+        ),
+    ) -> SceneCommentThreadResource:
+        if comment_service is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Scene comment functionality is not configured for this deployment.",
+            )
+
+        try:
+            return comment_service.add_comment(
+                project_id,
+                scene_id,
+                thread_id,
+                body=payload.body,
+                author_id=payload.author_id or acting_user_id,
+                author_display_name=payload.author_display_name,
+                acting_user_id=acting_user_id,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ProjectPermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    @router.post(
+        "/api/projects/{project_id}/scenes/{scene_id}/comments/{thread_id}/resolution",
+        response_model=SceneCommentThreadResource,
+        tags=["Scene Comments"],
+    )
+    def set_scene_comment_resolution(
+        project_id: str,
+        scene_id: str,
+        thread_id: str,
+        payload: SceneCommentResolveRequest,
+        acting_user_id: str | None = Query(
+            None,
+            description="Identifier of the collaborator updating the comment thread resolution state.",
+        ),
+    ) -> SceneCommentThreadResource:
+        if comment_service is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Scene comment functionality is not configured for this deployment.",
+            )
+
+        try:
+            return comment_service.set_resolution(
+                project_id,
+                scene_id,
+                thread_id,
+                resolved=payload.resolved,
+                acting_user_id=acting_user_id,
+            )
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ProjectPermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return router

--- a/src/textadventure/api/routes/projects.py
+++ b/src/textadventure/api/routes/projects.py
@@ -8,8 +8,6 @@ from ..models import (
     AdventureProjectDetailResponse,
     AdventureProjectListResponse,
     AdventureProjectTemplateListResponse,
-    ProjectCollaborationSessionListResponse,
-    ProjectCollaborationSessionRequest,
     ProjectCollaboratorListResponse,
     ProjectCollaboratorUpdateRequest,
     ProjectTemplateInstantiateRequest,
@@ -154,100 +152,6 @@ def create_projects_router(
                 collaborators=payload.collaborators,
                 acting_user_id=acting_user_id,
             )
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    # Collaboration Session Routes
-
-    @router.get(
-        "/api/projects/{project_id}/collaboration/sessions",
-        response_model=ProjectCollaborationSessionListResponse,
-        tags=["Projects"],
-    )
-    def list_project_collaboration_sessions(
-        project_id: str,
-    ) -> ProjectCollaborationSessionListResponse:
-        if project_service is None:
-            raise HTTPException(
-                status_code=501,
-                detail="Project service is not configured.",
-            )
-        try:
-            return project_service.list_collaboration_sessions(project_id=project_id)
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @router.post(
-        "/api/projects/{project_id}/collaboration/sessions",
-        response_model=ProjectCollaborationSessionListResponse,
-        tags=["Projects"],
-    )
-    def touch_project_collaboration_session(
-        project_id: str,
-        payload: ProjectCollaborationSessionRequest,
-        acting_user_id: str | None = Query(
-            None,
-            description=(
-                "Identifier of the collaborator performing the session update."
-            ),
-        ),
-    ) -> ProjectCollaborationSessionListResponse:
-        if project_service is None:
-            raise HTTPException(
-                status_code=501,
-                detail="Project service is not configured.",
-            )
-        try:
-            project_service.touch_collaboration_session(
-                project_id=project_id,
-                acting_user_id=acting_user_id,
-                session_id=payload.session_id,
-                scene_id=payload.scene_id,
-                ttl_seconds=payload.ttl_seconds,
-            )
-            return project_service.list_collaboration_sessions(project_id=project_id)
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @router.delete(
-        "/api/projects/{project_id}/collaboration/sessions/{session_id}",
-        response_model=ProjectCollaborationSessionListResponse,
-        tags=["Projects"],
-    )
-    def delete_project_collaboration_session(
-        project_id: str,
-        session_id: str,
-        acting_user_id: str | None = Query(
-            None,
-            description=(
-                "Identifier of the collaborator performing the session deletion."
-            ),
-        ),
-    ) -> ProjectCollaborationSessionListResponse:
-        if project_service is None:
-            raise HTTPException(
-                status_code=501,
-                detail="Project service is not configured.",
-            )
-        try:
-            project_service.end_collaboration_session(
-                project_id=project_id,
-                session_id=session_id,
-                acting_user_id=acting_user_id,
-            )
-            return project_service.list_collaboration_sessions(project_id=project_id)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         except ValueError as exc:

--- a/src/textadventure/api/routes/scenes.py
+++ b/src/textadventure/api/routes/scenes.py
@@ -17,10 +17,6 @@ from ..models import (
     SceneBranchListResponse,
     SceneBranchPlanRequest,
     SceneBranchPlanResponse,
-    SceneCommentReplyRequest,
-    SceneCommentResolveRequest,
-    SceneCommentThreadCreateRequest,
-    SceneCommentThreadListResponse,
     SceneCreateRequest,
     SceneDeleteResponse,
     SceneDetailResponse,
@@ -161,7 +157,6 @@ def _build_search_response(
 
 def create_scenes_router(
     scene_service: Any,
-    comment_service: Any | None = None,
     project_service: Any | None = None,
     *,
     active_scene_path: Path | None = None,
@@ -170,7 +165,6 @@ def create_scenes_router(
 
     Args:
         scene_service: Service for scene CRUD and validation operations
-        comment_service: Optional service for scene comment operations
         project_service: Optional service for project/permission operations
         active_scene_path: Path to the active scene dataset for permission checks
 
@@ -717,158 +711,6 @@ def create_scenes_router(
                 generated_at=payload.generated_at,
                 expected_base_version=payload.base_version_id,
             )
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    # Scene Comments Routes
-
-    @router.get(
-        "/api/projects/{project_id}/scenes/{scene_id}/comments",
-        response_model=SceneCommentThreadListResponse,
-        tags=["Scene Comments"],
-    )
-    def list_scene_comment_threads(
-        project_id: str,
-        scene_id: str,
-        *,
-        location_type: str | None = Query(
-            None,
-            description="Filter by comment location type (e.g., 'narration', 'choice_text').",
-        ),
-        choice_command: str | None = Query(
-            None,
-            description="Filter by choice command when querying choice-specific comments.",
-        ),
-    ) -> SceneCommentThreadListResponse:
-        if comment_service is None:
-            raise HTTPException(
-                status_code=501,
-                detail="Scene comment service is not configured.",
-            )
-        try:
-            return comment_service.list_threads(
-                project_id=project_id,
-                scene_id=scene_id,
-                location_type=location_type,
-                choice_command=choice_command,
-            )
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @router.post(
-        "/api/projects/{project_id}/scenes/{scene_id}/comments",
-        response_model=SceneCommentThreadListResponse,
-        status_code=201,
-        tags=["Scene Comments"],
-    )
-    def create_scene_comment_thread(
-        project_id: str,
-        scene_id: str,
-        payload: SceneCommentThreadCreateRequest,
-    ) -> SceneCommentThreadListResponse:
-        if comment_service is None:
-            raise HTTPException(
-                status_code=501,
-                detail="Scene comment service is not configured.",
-            )
-        try:
-            comment_service.create_thread(
-                project_id=project_id,
-                scene_id=scene_id,
-                location=payload.location,
-                body=payload.body,
-                author_id=payload.author_id,
-                author_display_name=payload.author_display_name,
-            )
-            return comment_service.list_threads(
-                project_id=project_id,
-                scene_id=scene_id,
-                location_type=None,
-                choice_command=None,
-            )
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @router.post(
-        "/api/projects/{project_id}/scenes/{scene_id}/comments/{thread_id}/replies",
-        response_model=SceneCommentThreadListResponse,
-        status_code=201,
-        tags=["Scene Comments"],
-    )
-    def add_scene_comment_reply(
-        project_id: str,
-        scene_id: str,
-        thread_id: str,
-        payload: SceneCommentReplyRequest,
-    ) -> SceneCommentThreadListResponse:
-        if comment_service is None:
-            raise HTTPException(
-                status_code=501,
-                detail="Scene comment service is not configured.",
-            )
-        try:
-            comment_service.add_comment(
-                project_id=project_id,
-                scene_id=scene_id,
-                thread_id=thread_id,
-                body=payload.body,
-                author_id=payload.author_id,
-                author_display_name=payload.author_display_name,
-            )
-            return comment_service.list_threads(
-                project_id=project_id,
-                scene_id=scene_id,
-                location_type=None,
-                choice_command=None,
-            )
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except RuntimeError as exc:
-            raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-    @router.post(
-        "/api/projects/{project_id}/scenes/{scene_id}/comments/{thread_id}/resolution",
-        response_model=SceneCommentThreadListResponse,
-        tags=["Scene Comments"],
-    )
-    def set_scene_comment_resolution(
-        project_id: str,
-        scene_id: str,
-        thread_id: str,
-        payload: SceneCommentResolveRequest,
-    ) -> SceneCommentThreadListResponse:
-        if comment_service is None:
-            raise HTTPException(
-                status_code=501,
-                detail="Scene comment service is not configured.",
-            )
-        try:
-            comment_service.set_resolution(
-                project_id=project_id,
-                scene_id=scene_id,
-                thread_id=thread_id,
-                resolved=payload.resolved,
-            )
-            return comment_service.list_threads(
-                project_id=project_id,
-                scene_id=scene_id,
-                location_type=None,
-                choice_command=None,
-            )
-        except KeyError as exc:
-            raise HTTPException(status_code=404, detail=str(exc)) from exc
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except RuntimeError as exc:


### PR DESCRIPTION
## Summary
- add a dedicated collaboration router covering project sessions and inline scene comments
- register the new router with the FastAPI app while trimming the projects/scenes routers to their domains
- mark the collaboration route extraction task complete in the backlog

## Testing
- black src tests
- ruff check src tests
- mypy src
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68f99f8f2e188324b1ea4ba57ac8368b